### PR TITLE
Improve NDVI Land Cover Explorer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ install.packages(c(
   "leaflet", "leaflet.extras", "lubridate", "promises",
   "raster", "shiny", "shinybusy", "shiny.i18n", "shinyjs",
   "shinyTree", "shinyWidgets", "sf", "terra", "tidyr",
-  "plotly", "htmlwidgets", "devtools"
+  "trend", "plotly", "htmlwidgets", "devtools"
 ))
 ```
 

--- a/app/DESCRIPTION
+++ b/app/DESCRIPTION
@@ -27,7 +27,8 @@ depends:
   leaflet,
   leaflet.extras,
   loggit,
-  htmlwidgets
+  htmlwidgets,
+  trend
 remotes:
   shinyTree/shinyTree
   

--- a/app/DESCRIPTION
+++ b/app/DESCRIPTION
@@ -20,6 +20,7 @@ depends:
   sp,
   terra,
   tidyr,
+  trend,
   plotly,
   ipc,
   future,
@@ -27,8 +28,7 @@ depends:
   leaflet,
   leaflet.extras,
   loggit,
-  htmlwidgets,
-  trend
+  htmlwidgets
 remotes:
   shinyTree/shinyTree
   

--- a/app/global.R
+++ b/app/global.R
@@ -17,6 +17,7 @@ library(shinyWidgets)
 library(sf)
 library(terra)
 library(tidyr)
+library(trend)
 library(plotly)
 library(htmlwidgets)
 

--- a/app/server.R
+++ b/app/server.R
@@ -298,6 +298,7 @@ server <- function(input, output, session) {
   output$lc_ndvi_plot_output <- plotly::renderPlotly({
     p <- lc_ts_plot_obj()
     shiny::req(p)
+    p <- plotly::event_register(p, "plotly_click")
     p <- plotly::event_register(p, "plotly_restyle")
     p <- plotly::event_register(p, "plotly_legendclick")
     p
@@ -345,6 +346,9 @@ server <- function(input, output, session) {
     } else {
       nm <- as.character(nm)[1]
     }
+    if (identical(nm, "Study area")) {
+      return(invisible(NULL))
+    }
     if (grepl("^Historical range", nm)) {
       lc_lc_highlight(NULL)
       lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, NULL)
@@ -370,7 +374,7 @@ server <- function(input, output, session) {
     }
   }
   
-  # Plotly chart click: highlight toggle + pan geo map to selected class
+  # Plotly chart or map click: highlight toggle + pan map to selected class
   observeEvent(plotly::event_data("plotly_click", source = "lc_ndvi_plot_output"), {
     ed <- plotly::event_data("plotly_click", source = "lc_ndvi_plot_output")
     shiny::req(ed)

--- a/app/server.R
+++ b/app/server.R
@@ -293,6 +293,7 @@ server <- function(input, output, session) {
   lc_ts_plot_obj <- reactiveVal(NULL)
   lc_map_obj <- reactiveVal(NULL)
   lc_lc_highlight <- reactiveVal(NULL)
+  lc_plot_year <- reactiveVal(NULL)
   
   output$lc_ndvi_plot_output <- plotly::renderPlotly({
     p <- lc_ts_plot_obj()
@@ -309,7 +310,7 @@ server <- function(input, output, session) {
         column(7,
                div(
                  class = "image-fill top-center ndvi-ts-plot-stack",
-                 ndvi_landcover_titles_ui(input$resolution),
+                 ndvi_landcover_titles_ui(input$resolution, year = lc_plot_year()),
                  plotlyOutput("lc_ndvi_plot_output", height = "550px"),
                  height = "auto"
                )),
@@ -361,6 +362,7 @@ server <- function(input, output, session) {
     lc_ts_plot_obj(NULL)
     lc_map_obj(NULL)
     lc_lc_highlight(NULL)
+    lc_plot_year(NULL)
   }, ignoreInit = TRUE)
   
   # Observe the Generate Figure button
@@ -373,6 +375,7 @@ server <- function(input, output, session) {
     lc_ts_plot_obj(NULL)
     lc_map_obj(NULL)
     lc_lc_highlight(NULL)
+    lc_plot_year(NULL)
     
     # Get user inputs
     country_name <- input$country
@@ -422,6 +425,7 @@ server <- function(input, output, session) {
       lc_ts_plot_obj(NULL)
       lc_map_obj(NULL)
       lc_lc_highlight(NULL)
+      lc_plot_year(NULL)
       
       # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 
@@ -468,6 +472,7 @@ server <- function(input, output, session) {
         filename    = lc_figure_filename
       )
       lc_map_obj(lc_map)
+      lc_plot_year(end_year)
       
       ndvi_lc_ready(TRUE) # Mark UI as ready as both figures are generated (renderUI will now return the container)
       error_message_rv(NULL) # Clear any previous error messages
@@ -479,6 +484,7 @@ server <- function(input, output, session) {
       lc_ts_plot_obj(NULL)
       lc_map_obj(NULL)
       lc_lc_highlight(NULL)
+      lc_plot_year(NULL)
       
       # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 

--- a/app/server.R
+++ b/app/server.R
@@ -165,8 +165,7 @@ server <- function(input, output, session) {
     
     if (is.null(error_msg) && isTRUE(ndvi_ts_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
       div(
-        class = "image-fill top-center",
-        style = "display: flex; flex-direction: column; align-items: stretch; width: 100%;",
+        class = "image-fill top-center ndvi-ts-plot-stack",
         ndvi_anomaly_titles_ui(input$resolution),
         plotlyOutput("ndvi_ts_plot_output", height = "550px"),
         height = "auto"

--- a/app/server.R
+++ b/app/server.R
@@ -151,6 +151,7 @@ server <- function(input, output, session) {
   ndvi_ts_ready <- reactiveVal(FALSE)
   # Plotly figure: set after successful generate (works with conditional UI + renderPlotly).
   ndvi_ts_plot_obj <- reactiveVal(NULL)
+  ndvi_ts_stats <- reactiveVal(NULL)
   
   output$ndvi_ts_plot_output <- plotly::renderPlotly({
     p <- ndvi_ts_plot_obj()
@@ -167,7 +168,7 @@ server <- function(input, output, session) {
         class = "image-fill top-center",
         style = "display: flex; flex-direction: column; align-items: stretch; width: 100%;",
         ndvi_anomaly_titles_ui(input$resolution),
-        plotlyOutput("ndvi_ts_plot_output", height = "640px"),
+        plotlyOutput("ndvi_ts_plot_output", height = "550px"),
         height = "auto"
       )
     } else {
@@ -175,11 +176,28 @@ server <- function(input, output, session) {
     }
   })
   
+  output$wilcoxon_card <- renderUI({
+    s <- ndvi_ts_stats()
+    if (is.null(s) || !isTRUE(ndvi_ts_ready())) {
+      return(NULL)
+    }
+    ndvi_insight_wilcox_card_ui(s)
+  })
+  
+  output$smk_card <- renderUI({
+    s <- ndvi_ts_stats()
+    if (is.null(s) || !isTRUE(ndvi_ts_ready())) {
+      return(NULL)
+    }
+    ndvi_insight_smk_card_ui(s)
+  })
+  
   # Clear the image when switching tabs or subtabs
   observeEvent(list(input$tabs, input$ndvisubtabs), {
     ndvi_ts_ready(FALSE)
     error_message_rv(NULL)
     ndvi_ts_plot_obj(NULL)
+    ndvi_ts_stats(NULL)
   })
   
   # Observe the Generate Figure button
@@ -189,6 +207,7 @@ server <- function(input, output, session) {
     # To be extra sure that no figure is shown, clear previous error messages
     ndvi_ts_ready(FALSE)
     ndvi_ts_plot_obj(NULL)
+    ndvi_ts_stats(NULL)
     error_message_rv(NULL)
     
     # Get user inputs
@@ -216,7 +235,7 @@ server <- function(input, output, session) {
         dir.create(figures_dir, recursive = TRUE)
       }
       
-      ndvi_plotly <- generate_timeseries(
+      ndvi_result <- generate_timeseries(
         country_name    = country_name,
         resolution      = resolution,
         end_year        = end_year,
@@ -228,13 +247,15 @@ server <- function(input, output, session) {
       )
       
       ndvi_ts_ready(TRUE)
-      ndvi_ts_plot_obj(ndvi_plotly)
+      ndvi_ts_plot_obj(ndvi_result$plot)
+      ndvi_ts_stats(ndvi_result$stats)
       error_message_rv(NULL) # Clear any previous error messages
       
     }, error = function(e) {
       # Clear server outputs so nothing can re-appear
       ndvi_ts_ready(FALSE)
       ndvi_ts_plot_obj(NULL)
+      ndvi_ts_stats(NULL)
       error_message_rv(e$message)
       
       # Show error notification to user

--- a/app/server.R
+++ b/app/server.R
@@ -291,6 +291,8 @@ server <- function(input, output, session) {
   # Reactive flag to control whether the NDVI Land Cover UI should be shown
   ndvi_lc_ready <- reactiveVal(FALSE)
   lc_ts_plot_obj <- reactiveVal(NULL)
+  lc_map_obj <- reactiveVal(NULL)
+  lc_lc_highlight <- reactiveVal(NULL)
   
   output$lc_ndvi_plot_output <- plotly::renderPlotly({
     p <- lc_ts_plot_obj()
@@ -311,10 +313,44 @@ server <- function(input, output, session) {
                  plotlyOutput("lc_ndvi_plot_output", height = "550px"),
                  height = "auto"
                )),
-        column(5, uiOutput("landcover_map_output"))
+        column(5, leafletOutput("lc_landcover_map", height = "500px"))
       )
     } else {
       return(NULL) # Return empty UI
+    }
+  })
+  
+  output$lc_landcover_map <- leaflet::renderLeaflet({
+    m <- lc_map_obj()
+    shiny::req(m)
+    m
+  })
+  
+  # Land Cover map polygon click: emphasize matching Plotly line (toggle same class to clear)
+  observeEvent(input$lc_landcover_map_shape_click, {
+    shiny::req(ndvi_lc_ready())
+    p <- lc_ts_plot_obj()
+    shiny::req(p)
+    stem <- input$lc_landcover_map_shape_click$group
+    if (is.null(stem) || !nzchar(stem)) {
+      return(invisible(NULL))
+    }
+    key <- geojson_stem_to_class_key(stem)
+    if (is.na(key)) {
+      return(invisible(NULL))
+    }
+    labs <- land_cover_class_legend_labels()
+    if (!key %in% names(labs)) {
+      return(invisible(NULL))
+    }
+    lab <- unname(labs[[key]])
+    cur <- lc_lc_highlight()
+    if (!is.null(cur) && identical(cur, lab)) {
+      lc_lc_highlight(NULL)
+      lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, NULL)
+    } else {
+      lc_lc_highlight(lab)
+      lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, lab)
     }
   })
   
@@ -323,9 +359,8 @@ server <- function(input, output, session) {
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
     lc_ts_plot_obj(NULL)
-    
-    # Clear server outputs so nothing can re-appear
-    output$landcover_map_output <- renderUI(NULL)
+    lc_map_obj(NULL)
+    lc_lc_highlight(NULL)
   }, ignoreInit = TRUE)
   
   # Observe the Generate Figure button
@@ -336,6 +371,8 @@ server <- function(input, output, session) {
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
     lc_ts_plot_obj(NULL)
+    lc_map_obj(NULL)
+    lc_lc_highlight(NULL)
     
     # Get user inputs
     country_name <- input$country
@@ -383,7 +420,8 @@ server <- function(input, output, session) {
       ndvi_lc_ready(FALSE)
       error_message_rv(e$message)
       lc_ts_plot_obj(NULL)
-      output$landcover_map_output <- renderUI(NULL)
+      lc_map_obj(NULL)
+      lc_lc_highlight(NULL)
       
       # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 
@@ -419,31 +457,17 @@ server <- function(input, output, session) {
     # Use tryCatch to handle missing data or any errors
     tryCatch({
       
-      # If figure not stored yet, try to generate it
-      if (!file.exists(lc_figure_path)) {
-        
-        # Ensure the figures directory exists
-        if (!dir.exists(figures_dir)) {
-          dir.create(figures_dir, recursive = TRUE)
-        }
-        
-        # Create explorer plot
-        plot_geojsons_from_a_folder(
-          folder_path = data_path,
-          save_path = figures_dir,
-          filename = lc_figure_filename
-        )
+      if (!dir.exists(figures_dir)) {
+        dir.create(figures_dir, recursive = TRUE)
       }
       
-      # Render the generated (or existing) HTML
-      output$landcover_map_output <- renderUI({
-        tags$iframe(
-          src = paste0("figures/", lc_figure_filename),
-          width = "100%",
-          height = "500px",
-          frameborder = 0
-        )
-      })
+      # Build Leaflet for Shiny (always) and save HTML for export/bookmarks
+      lc_map <- plot_geojsons_from_a_folder(
+        folder_path = data_path,
+        save_path   = figures_dir,
+        filename    = lc_figure_filename
+      )
+      lc_map_obj(lc_map)
       
       ndvi_lc_ready(TRUE) # Mark UI as ready as both figures are generated (renderUI will now return the container)
       error_message_rv(NULL) # Clear any previous error messages
@@ -453,7 +477,8 @@ server <- function(input, output, session) {
       ndvi_lc_ready(FALSE)
       error_message_rv(e$message)
       lc_ts_plot_obj(NULL)
-      output$landcover_map_output <- renderUI(NULL)
+      lc_map_obj(NULL)
+      lc_lc_highlight(NULL)
       
       # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 

--- a/app/server.R
+++ b/app/server.R
@@ -291,13 +291,15 @@ server <- function(input, output, session) {
   # Reactive flag to control whether the NDVI Land Cover UI should be shown
   ndvi_lc_ready <- reactiveVal(FALSE)
   lc_ts_plot_obj <- reactiveVal(NULL)
-  lc_map_obj <- reactiveVal(NULL)
   lc_lc_highlight <- reactiveVal(NULL)
   lc_plot_year <- reactiveVal(NULL)
+  lc_map_bbox_by_stem <- reactiveVal(NULL)
   
   output$lc_ndvi_plot_output <- plotly::renderPlotly({
     p <- lc_ts_plot_obj()
     shiny::req(p)
+    p <- plotly::event_register(p, "plotly_restyle")
+    p <- plotly::event_register(p, "plotly_legendclick")
     p
   })
   
@@ -307,62 +309,89 @@ server <- function(input, output, session) {
     
     if (is.null(error_msg) && isTRUE(ndvi_lc_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
       fluidRow(
-        column(7,
+        column(12,
                div(
                  class = "image-fill top-center ndvi-ts-plot-stack",
                  ndvi_landcover_titles_ui(input$resolution, year = lc_plot_year()),
-                 plotlyOutput("lc_ndvi_plot_output", height = "550px"),
+                 plotlyOutput("lc_ndvi_plot_output", height = "1050px"),
                  height = "auto"
-               )),
-        column(5, leafletOutput("lc_landcover_map", height = "500px"))
+               ))
       )
     } else {
       return(NULL) # Return empty UI
     }
   })
   
-  output$lc_landcover_map <- leaflet::renderLeaflet({
-    m <- lc_map_obj()
-    shiny::req(m)
-    m
-  })
-  
-  # Land Cover map polygon click: emphasize matching Plotly line (toggle same class to clear)
-  observeEvent(input$lc_landcover_map_shape_click, {
+  # Shared logic for plotly_click and plotly_legendclick: highlight, optional geo fitBounds
+  lc_handle_ndvi_plotly_selection <- function(ed) {
     shiny::req(ndvi_lc_ready())
     p <- lc_ts_plot_obj()
     shiny::req(p)
-    stem <- input$lc_landcover_map_shape_click$group
-    if (is.null(stem) || !nzchar(stem)) {
+    if (!is.data.frame(ed) || nrow(ed) < 1L) {
       return(invisible(NULL))
     }
-    key <- geojson_stem_to_class_key(stem)
-    if (is.na(key)) {
+    cn <- ed$curveNumber[1]
+    if (length(cn) == 0L || is.na(cn)) {
       return(invisible(NULL))
     }
-    labs <- land_cover_class_legend_labels()
-    if (!key %in% names(labs)) {
+    pb <- plotly::plotly_build(p)
+    idx <- as.integer(cn) + 1L
+    if (idx < 1L || idx > length(pb$x$data)) {
       return(invisible(NULL))
     }
-    lab <- unname(labs[[key]])
+    nm <- pb$x$data[[idx]]$name
+    if (is.null(nm)) {
+      nm <- ""
+    } else {
+      nm <- as.character(nm)[1]
+    }
+    if (grepl("^Historical range", nm)) {
+      lc_lc_highlight(NULL)
+      lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, NULL)
+      return(invisible(NULL))
+    }
+    lab <- nm
+    labs_vals <- unname(land_cover_class_legend_labels())
+    if (!lab %in% labs_vals) {
+      return(invisible(NULL))
+    }
     cur <- lc_lc_highlight()
+    bbs <- lc_map_bbox_by_stem()
     if (!is.null(cur) && identical(cur, lab)) {
       lc_lc_highlight(NULL)
       lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, NULL)
     } else {
       lc_lc_highlight(lab)
       lc_landcover_emphasize_plotly_traces(session, "lc_ndvi_plot_output", p, lab)
+      stem <- landcover_label_to_stem(lab, bbs)
+      if (!is.na(stem) && !is.null(bbs[[stem]])) {
+        lc_plotly_relayout_geo_bbox(session, "lc_ndvi_plot_output", p, bbs[[stem]])
+      }
     }
-  })
+  }
+  
+  # Plotly chart click: highlight toggle + pan geo map to selected class
+  observeEvent(plotly::event_data("plotly_click", source = "lc_ndvi_plot_output"), {
+    ed <- plotly::event_data("plotly_click", source = "lc_ndvi_plot_output")
+    shiny::req(ed)
+    lc_handle_ndvi_plotly_selection(ed)
+  }, ignoreInit = TRUE, ignoreNULL = TRUE)
+  
+  # Plotly legend (line names): same behavior when legend fires events
+  observeEvent(plotly::event_data("plotly_legendclick", source = "lc_ndvi_plot_output"), {
+    ed <- plotly::event_data("plotly_legendclick", source = "lc_ndvi_plot_output")
+    shiny::req(ed)
+    lc_handle_ndvi_plotly_selection(ed)
+  }, ignoreInit = TRUE, ignoreNULL = TRUE)
   
   # Clear the image when switching tabs or subtabs
   observeEvent(list(input$tabs, input$ndvisubtabs), {
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
     lc_ts_plot_obj(NULL)
-    lc_map_obj(NULL)
     lc_lc_highlight(NULL)
     lc_plot_year(NULL)
+    lc_map_bbox_by_stem(NULL)
   }, ignoreInit = TRUE)
   
   # Observe the Generate Figure button
@@ -373,9 +402,9 @@ server <- function(input, output, session) {
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
     lc_ts_plot_obj(NULL)
-    lc_map_obj(NULL)
     lc_lc_highlight(NULL)
     lc_plot_year(NULL)
+    lc_map_bbox_by_stem(NULL)
     
     # Get user inputs
     country_name <- input$country
@@ -394,13 +423,13 @@ server <- function(input, output, session) {
       end_year <- input$year
     }
     
-    # Land Cover map paths (defined before tryCatch so error handlers can reference them)
     map_year <- "2023"
     vector_src <- "S2_10m_LULC"
     lc_figure_filename <- paste0("figure_LULCmap_", country_name, "_", vector_src, "_", map_year, ".html")
     lc_figure_path <- file.path(figures_dir, lc_figure_filename)
+    data_path <- file.path(data_dir, "LandUse", country_name, paste0(vector_src, "_", map_year))
     
-    # Interactive Plotly time series (all land-cover classes + AoI ribbon)
+    # NDVI time series + Plotly geo map (shared legend via legendgroup); falls back to chart-only if no map folder
     tryCatch({
       if (!dir.exists(figures_dir)) {
         dir.create(figures_dir, recursive = TRUE)
@@ -414,90 +443,37 @@ server <- function(input, output, session) {
         figures_dir  = figures_dir,
         data_dir     = data_dir,
         land_use_src = "S2_10m_LULC_2023",
-        return_plot  = TRUE
+        return_plot  = TRUE,
+        lulc_map_folder_path = data_path
       )
       lc_ts_plot_obj(lc_result$plot)
-      
-    }, error = function(e) {
-      # Clear server outputs so nothing can re-appear
-      ndvi_lc_ready(FALSE)
-      error_message_rv(e$message)
-      lc_ts_plot_obj(NULL)
-      lc_map_obj(NULL)
-      lc_lc_highlight(NULL)
-      lc_plot_year(NULL)
-      
-      # Show error notification to user
-      showNotification(HTML("The figure cannot be generated due to missing data. 
-       Please contact us at 
-       <a href='mailto:helpdesk@sensingclues.org'>helpdesk@sensingclues.org</a> for assistance."), 
-                       type = "error", 
-                       duration = 6)
-      
-      # Optionally, also log the error to the console for debugging
-      message("---Error generating NDVI Land Cover (old message)---", "\n",
-              "An error occurred while generating or reading the NDVI timeseries data. ", "\n",
-              "This may be due to missing files or incorrect file paths. ", "\n",
-              "Please verify that the necessary data files exist in '", data_dir, "'.", "\n",
-              paste("Details:", e$message), "\n",
-              paste("Country Name:", country_name), "\n",
-              paste("Resolution:", resolution), "\n",
-              paste("End Year:", end_year), "\n",
-              paste("End Month:", end_month), "\n",
-              paste("Figures Directory:", figures_dir), "\n",
-              paste("Data Directory:", data_dir), "\n",
-              paste("Land Cover Figure Directory:", lc_figure_path))
-      
-      # Optionally, also log the error to the console for debugging
-      message("Error generating Land Cover NDVI Timeseries: ", e$message)
-    })
-    
-    #### Land Cover map
-    # Input geojsons stored in country folder.
-    data_path <- paste0(data_dir, "/", "LandUse", "/", 
-                        country_name, "/", 
-                        vector_src, "_", map_year, "/")
-    
-    # Use tryCatch to handle missing data or any errors
-    tryCatch({
-      
-      if (!dir.exists(figures_dir)) {
-        dir.create(figures_dir, recursive = TRUE)
-      }
-      
-      # Build Leaflet for Shiny (always) and save HTML for export/bookmarks
-      lc_map <- plot_geojsons_from_a_folder(
-        folder_path = data_path,
-        save_path   = figures_dir,
-        filename    = lc_figure_filename
-      )
-      lc_map_obj(lc_map)
+      lc_map_bbox_by_stem(lc_result$bbox_by_stem)
       lc_plot_year(end_year)
       
-      ndvi_lc_ready(TRUE) # Mark UI as ready as both figures are generated (renderUI will now return the container)
-      error_message_rv(NULL) # Clear any previous error messages
-
+      htmlwidgets::saveWidget(
+        lc_result$plot,
+        file.path(figures_dir, lc_figure_filename),
+        selfcontained = TRUE
+      )
+      
+      ndvi_lc_ready(TRUE)
+      error_message_rv(NULL)
+      
     }, error = function(e) {
-      # Clear server outputs so nothing can re-appear
       ndvi_lc_ready(FALSE)
       error_message_rv(e$message)
       lc_ts_plot_obj(NULL)
-      lc_map_obj(NULL)
       lc_lc_highlight(NULL)
       lc_plot_year(NULL)
+      lc_map_bbox_by_stem(NULL)
       
-      # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 
        Please contact us at 
        <a href='mailto:helpdesk@sensingclues.org'>helpdesk@sensingclues.org</a> for assistance."), 
                        type = "error", 
                        duration = 6)
       
-      # Optionally, also log the error to the console for debugging
-      message("---Error generating NDVI Land Cover (old message)---", "\n",
-              "An error occurred while generating or reading the NDVI timeseries data. ", "\n",
-              "This may be due to missing files or incorrect file paths. ", "\n",
-              "Please verify that the necessary data files exist in '", data_dir, "'.", "\n",
+      message("---Error generating NDVI Land Cover---", "\n",
               paste("Details:", e$message), "\n",
               paste("Country Name:", country_name), "\n",
               paste("Resolution:", resolution), "\n",
@@ -507,8 +483,7 @@ server <- function(input, output, session) {
               paste("Data Directory:", data_dir), "\n",
               paste("Land Cover Figure Directory:", lc_figure_path))
       
-      # You could also log the error or print it to console
-      message("Error generating land use map: ", e$message)
+      message("Error generating Land Cover NDVI / map: ", e$message)
     })
     message("=========== End of NDVI Land Cover Generation =============")
   })

--- a/app/server.R
+++ b/app/server.R
@@ -314,7 +314,7 @@ server <- function(input, output, session) {
                div(
                  class = "image-fill top-center ndvi-ts-plot-stack",
                  ndvi_landcover_titles_ui(input$resolution, year = lc_plot_year()),
-                 plotlyOutput("lc_ndvi_plot_output", height = "1050px"),
+                 plotlyOutput("lc_ndvi_plot_output", height = "1200px"),
                  height = "auto"
                ))
       )

--- a/app/server.R
+++ b/app/server.R
@@ -149,15 +149,27 @@ server <- function(input, output, session) {
   
   # Reactive flag to control whether the NDVI timeseries UI should be shown
   ndvi_ts_ready <- reactiveVal(FALSE)
+  # Plotly figure: set after successful generate (works with conditional UI + renderPlotly).
+  ndvi_ts_plot_obj <- reactiveVal(NULL)
+  
+  output$ndvi_ts_plot_output <- plotly::renderPlotly({
+    p <- ndvi_ts_plot_obj()
+    shiny::req(p)
+    p
+  })
   
   # Render a container for the plot or error message
   output$ndvi_ts_plot_container <- renderUI({
     error_msg <- error_message_rv()
     
     if (is.null(error_msg) && isTRUE(ndvi_ts_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
-      div(class = "image-fill top-center",
-          plotlyOutput("ndvi_ts_plot_output", height = "640px"),
-          height = "auto")
+      div(
+        class = "image-fill top-center",
+        style = "display: flex; flex-direction: column; align-items: stretch; width: 100%;",
+        ndvi_anomaly_titles_ui(input$resolution),
+        plotlyOutput("ndvi_ts_plot_output", height = "640px"),
+        height = "auto"
+      )
     } else {
       return(NULL) # Return empty UI
     }
@@ -166,9 +178,8 @@ server <- function(input, output, session) {
   # Clear the image when switching tabs or subtabs
   observeEvent(list(input$tabs, input$ndvisubtabs), {
     ndvi_ts_ready(FALSE)
-    error_message_rv(NULL) 
-    
-    output$ndvi_ts_plot_output <- NULL
+    error_message_rv(NULL)
+    ndvi_ts_plot_obj(NULL)
   })
   
   # Observe the Generate Figure button
@@ -177,6 +188,7 @@ server <- function(input, output, session) {
     
     # To be extra sure that no figure is shown, clear previous error messages
     ndvi_ts_ready(FALSE)
+    ndvi_ts_plot_obj(NULL)
     error_message_rv(NULL)
     
     # Get user inputs
@@ -215,18 +227,15 @@ server <- function(input, output, session) {
         figure_filename = NULL
       )
       
-      output$ndvi_ts_plot_output <- plotly::renderPlotly({
-        ndvi_plotly
-      })
-      
-      ndvi_ts_ready(TRUE) # Mark UI as ready (renderUI will now return the container)
+      ndvi_ts_ready(TRUE)
+      ndvi_ts_plot_obj(ndvi_plotly)
       error_message_rv(NULL) # Clear any previous error messages
       
     }, error = function(e) {
       # Clear server outputs so nothing can re-appear
       ndvi_ts_ready(FALSE)
+      ndvi_ts_plot_obj(NULL)
       error_message_rv(e$message)
-      output$ndvi_ts_plot_output <- NULL
       
       # Show error notification to user
       showNotification(HTML("The figure cannot be generated due to missing data. 

--- a/app/server.R
+++ b/app/server.R
@@ -314,7 +314,7 @@ server <- function(input, output, session) {
                div(
                  class = "image-fill top-center ndvi-ts-plot-stack",
                  ndvi_landcover_titles_ui(input$resolution, year = lc_plot_year()),
-                 plotlyOutput("lc_ndvi_plot_output", height = "1200px"),
+                 plotlyOutput("lc_ndvi_plot_output", height = "1050px"),
                  height = "auto"
                ))
       )

--- a/app/server.R
+++ b/app/server.R
@@ -156,7 +156,7 @@ server <- function(input, output, session) {
     
     if (is.null(error_msg) && isTRUE(ndvi_ts_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
       div(class = "image-fill top-center",
-          imageOutput("ndvi_ts_plot_output"), 
+          plotlyOutput("ndvi_ts_plot_output", height = "640px"),
           height = "auto")
     } else {
       return(NULL) # Return empty UI
@@ -196,40 +196,28 @@ server <- function(input, output, session) {
       end_year <- input$year
     }
     
-    # Define script and figure paths
-    figure_filename <- paste0("figure_NDVItimeseries_", country_name, "_", 
-                              end_month, "_", end_year, "_", resolution, "m", ".png")
-    figure_path <- file.path(figures_dir, figure_filename)
-    
     # Wrap data generation in tryCatch to handle missing files/errors
     tryCatch({
       
-      # If figure not stored yet, attempt to generate it
-      if (!file.exists(figure_path)) {
-        
-        # Ensure the figures directory exists
-        if (!dir.exists(figures_dir)) {
-          dir.create(figures_dir, recursive = TRUE)
-        }
-        
-        # Create timeseries plot
-        generate_timeseries(
-          country_name   = country_name,
-          resolution     = resolution,
-          end_year       = end_year,
-          end_month      = end_month,
-          figures_dir    = figures_dir,
-          data_dir       = data_dir,
-          return_plot    = FALSE,
-          figure_filename= figure_filename
-        )
+      # Ensure the figures directory exists (used by other exports; NDVI TS is plotly)
+      if (!dir.exists(figures_dir)) {
+        dir.create(figures_dir, recursive = TRUE)
       }
       
-      # If no error so far, render the image
-      output$ndvi_ts_plot_output <- renderImage({
-        list(src   = figure_path,
-             alt   = "NDVI timeseries")
-      }, deleteFile = FALSE)
+      ndvi_plotly <- generate_timeseries(
+        country_name    = country_name,
+        resolution      = resolution,
+        end_year        = end_year,
+        end_month       = end_month,
+        figures_dir     = figures_dir,
+        data_dir        = data_dir,
+        return_plot     = TRUE,
+        figure_filename = NULL
+      )
+      
+      output$ndvi_ts_plot_output <- plotly::renderPlotly({
+        ndvi_plotly
+      })
       
       ndvi_ts_ready(TRUE) # Mark UI as ready (renderUI will now return the container)
       error_message_rv(NULL) # Clear any previous error messages

--- a/app/server.R
+++ b/app/server.R
@@ -290,6 +290,13 @@ server <- function(input, output, session) {
   
   # Reactive flag to control whether the NDVI Land Cover UI should be shown
   ndvi_lc_ready <- reactiveVal(FALSE)
+  lc_ts_plot_obj <- reactiveVal(NULL)
+  
+  output$lc_ndvi_plot_output <- plotly::renderPlotly({
+    p <- lc_ts_plot_obj()
+    shiny::req(p)
+    p
+  })
   
   # Render a container for the plot or error message
   output$lc_plot_container <- renderUI({
@@ -297,9 +304,13 @@ server <- function(input, output, session) {
     
     if (is.null(error_msg) && isTRUE(ndvi_lc_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
       fluidRow(
-        column(7, 
-               div(class = "image-fill top-center",
-                   imageOutput("ndvi_plot_output"), height = "100%")),
+        column(7,
+               div(
+                 class = "image-fill top-center ndvi-ts-plot-stack",
+                 ndvi_landcover_titles_ui(input$resolution),
+                 plotlyOutput("lc_ndvi_plot_output", height = "550px"),
+                 height = "auto"
+               )),
         column(5, uiOutput("landcover_map_output"))
       )
     } else {
@@ -311,10 +322,10 @@ server <- function(input, output, session) {
   observeEvent(list(input$tabs, input$ndvisubtabs), {
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
+    lc_ts_plot_obj(NULL)
     
     # Clear server outputs so nothing can re-appear
-    output$ndvi_plot_output <- NULL
-    output$landcover_map_output <- renderUI(NULL)   
+    output$landcover_map_output <- renderUI(NULL)
   }, ignoreInit = TRUE)
   
   # Observe the Generate Figure button
@@ -324,11 +335,11 @@ server <- function(input, output, session) {
     # To be extra sure that no figure is shown, clear previous error messages
     ndvi_lc_ready(FALSE)
     error_message_rv(NULL)
+    lc_ts_plot_obj(NULL)
     
     # Get user inputs
     country_name <- input$country
     resolution <- input$resolution
-    landcover_Type <- input$landcover_Type
     
     # Handling to avoid end/start of new year errors
     if(input$year == lubridate::year(Sys.Date())) {
@@ -343,47 +354,35 @@ server <- function(input, output, session) {
       end_year <- input$year
     }
     
-    # Define script and figure paths
-    figure_filename <- paste0("figure_landCover_", country_name, "_", 
-                              end_month, "_", end_year, "_", resolution, "m", "_", landcover_Type, ".png")
-    figure_path <- file.path(figures_dir, figure_filename)
+    # Land Cover map paths (defined before tryCatch so error handlers can reference them)
+    map_year <- "2023"
+    vector_src <- "S2_10m_LULC"
+    lc_figure_filename <- paste0("figure_LULCmap_", country_name, "_", vector_src, "_", map_year, ".html")
+    lc_figure_path <- file.path(figures_dir, lc_figure_filename)
     
-    # Wrap data generation in tryCatch to handle missing files/errors
+    # Interactive Plotly time series (all land-cover classes + AoI ribbon)
     tryCatch({
-      
-      # If figure not stored yet, attempt to generate it
-      if (!file.exists(figure_path)) {
-        
-        # Ensure the figures directory exists
-        if (!dir.exists(figures_dir)) {
-          dir.create(figures_dir, recursive = TRUE)
-        }
-        
-        # Create timeseries plot
-        generate_timeseries_landcover(
-          country_name   = country_name,
-          resolution     = resolution,
-          end_year       = end_year,
-          end_month      = end_month,
-          figures_dir    = figures_dir,
-          data_dir       = data_dir,
-          land_use_src   = "S2_10m_LULC_2023",
-          land_cover_type = landcover_Type,
-          return_plot    = FALSE,
-          figure_filename= figure_filename
-        )
+      if (!dir.exists(figures_dir)) {
+        dir.create(figures_dir, recursive = TRUE)
       }
       
-      # If no error so far, render the image
-      output$ndvi_plot_output <- renderImage({
-        list(src = figure_path, alt = "Land Cover")
-      }, deleteFile = FALSE)
+      lc_result <- generate_timeseries_landcover(
+        country_name = country_name,
+        resolution   = resolution,
+        end_year     = end_year,
+        end_month    = end_month,
+        figures_dir  = figures_dir,
+        data_dir     = data_dir,
+        land_use_src = "S2_10m_LULC_2023",
+        return_plot  = TRUE
+      )
+      lc_ts_plot_obj(lc_result$plot)
       
     }, error = function(e) {
       # Clear server outputs so nothing can re-appear
       ndvi_lc_ready(FALSE)
       error_message_rv(e$message)
-      output$ndvi_plot_output <- NULL
+      lc_ts_plot_obj(NULL)
       output$landcover_map_output <- renderUI(NULL)
       
       # Show error notification to user
@@ -402,8 +401,7 @@ server <- function(input, output, session) {
               paste("Country Name:", country_name), "\n",
               paste("Resolution:", resolution), "\n",
               paste("End Year:", end_year), "\n",
-              paste("End Month:", end_month), "\n", 
-              paste("Land Cover Type:", landcover_Type), "\n",
+              paste("End Month:", end_month), "\n",
               paste("Figures Directory:", figures_dir), "\n",
               paste("Data Directory:", data_dir), "\n",
               paste("Land Cover Figure Directory:", lc_figure_path))
@@ -413,18 +411,10 @@ server <- function(input, output, session) {
     })
     
     #### Land Cover map
-    # Get additional inputs for folder selection
-    map_year <- "2023"
-    vector_src <- "S2_10m_LULC"
-    
-    # Input geojsons stored in country folder. 
+    # Input geojsons stored in country folder.
     data_path <- paste0(data_dir, "/", "LandUse", "/", 
                         country_name, "/", 
                         vector_src, "_", map_year, "/")
-    
-    # Define script and figure paths
-    lc_figure_filename <- paste0("figure_LULCmap_", country_name, "_", vector_src, "_", map_year, ".html")
-    lc_figure_path <- file.path(figures_dir, lc_figure_filename)
     
     # Use tryCatch to handle missing data or any errors
     tryCatch({
@@ -462,7 +452,7 @@ server <- function(input, output, session) {
       # Clear server outputs so nothing can re-appear
       ndvi_lc_ready(FALSE)
       error_message_rv(e$message)
-      output$ndvi_plot_output <- NULL
+      lc_ts_plot_obj(NULL)
       output$landcover_map_output <- renderUI(NULL)
       
       # Show error notification to user
@@ -481,8 +471,7 @@ server <- function(input, output, session) {
               paste("Country Name:", country_name), "\n",
               paste("Resolution:", resolution), "\n",
               paste("End Year:", end_year), "\n",
-              paste("End Month:", end_month), "\n", 
-              paste("Land Cover Type:", landcover_Type), "\n",
+              paste("End Month:", end_month), "\n",
               paste("Figures Directory:", figures_dir), "\n",
               paste("Data Directory:", data_dir), "\n",
               paste("Land Cover Figure Directory:", lc_figure_path))

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -71,8 +71,7 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
   ## Interactive plotly: NDVI vs climatology + historic range + monthly anomalies
   ndvi_ts_plot <- plot_ndvi_anomaly(
     train_ndvi_df = train_ndvi_df,
-    test_ndvi_df  = test_ndvi_df,
-    resolution    = resolution
+    test_ndvi_df  = test_ndvi_df
   )
   
   if (isTRUE(return_plot)) {

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -478,7 +478,7 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                     aoi_proj = aoi_proj)
   
   # AoI-wide historic ribbon (not masked by land cover class)
-  train_ndvi_df_aoi <- get_ndvi_df(ndvi_rast = train_ndvi_msk, dates = train_files_df$dates)
+  train_ndvi_df_aoi <- get_ndvi_global_means_df(ndvi_rast = train_ndvi_msk, dates = train_files_df$dates)
   train_ndvi_summary_aoi <- get_summary_ndvi_df(ndvi_df = train_ndvi_df_aoi)
   
   land_cover_summaries_list <- vector("list", length(land_cover_classes))
@@ -493,8 +493,8 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                   projection = "EPSG:4326")
     test_ndvi_lc <- mask(test_ndvi_msk, land_use_lc)
     train_ndvi_lc <- mask(train_ndvi_msk, land_use_lc)
-    test_ndvi_df_lc <- get_ndvi_df(ndvi_rast = test_ndvi_lc, dates = test_files_df$dates)
-    train_ndvi_df_lc <- get_ndvi_df(ndvi_rast = train_ndvi_lc, dates = train_files_df$dates)
+    test_ndvi_df_lc <- get_ndvi_global_means_df(ndvi_rast = test_ndvi_lc, dates = test_files_df$dates)
+    train_ndvi_df_lc <- get_ndvi_global_means_df(ndvi_rast = train_ndvi_lc, dates = train_files_df$dates)
     test_ndvi_summary_lc <- get_summary_ndvi_df(ndvi_df = test_ndvi_df_lc)
     train_ndvi_summary_lc <- get_summary_ndvi_df(ndvi_df = train_ndvi_df_lc)
     land_cover_summaries_list[[lc]] <- dplyr::bind_rows(

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -425,72 +425,48 @@ generate_ba_export <- function(country_name = NULL, resolution = NULL,
   return(geojson_export_path)
 }
 
-# Function to create NDVI timeseries plot
-generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL, land_cover_type = NULL, land_use_src = NULL,
+# Function to create NDVI timeseries by land cover (all classes, Plotly when return_plot = TRUE)
+generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL, land_use_src = NULL,
                                           end_year = NULL, end_month = NULL,
                                           figures_dir = NULL, data_dir = NULL,
-                                          return_plot = FALSE, figure_filename = NULL
+                                          return_plot = FALSE, figure_filename = NULL,
+                                          land_cover_classes = c(
+                                            "Crops", "Rangeland", "Water", "Trees",
+                                            "Flooded_vegetation", "Built_Area", "Bare_ground"
+                                          )
 ) {
-  
-  ### Set paths and define parameters
-  
-  # figure path
-  figure_path <- file.path(figures_dir, figure_filename)
   
   data_type <- "NDVI"
   Sys.setlocale("LC_TIME", "C") # Otherwise creates language inconsistencies, at least locally
   
-  
-  # Input NVDI basemaps stored in country folder. 
-  data_path <- file.path(data_dir, paste0(data_type, "/", 
-                                          country_name, "/", 
+  data_path <- file.path(data_dir, paste0(data_type, "/",
+                                          country_name, "/",
                                           resolution, "m_resolution/"))
-  # Area of Interest (AoI) files in AoI folder
   aoi_path <- file.path(data_dir, "AoI/")
-  
-  # Land use files path
   lulc_path <- file.path(data_dir, paste0("LandUse/", country_name, "/", land_use_src, "/"))
   
-  ## define end and start date for test data
-  end_date <- as.Date(paste(end_year, end_month, 1, sep="-"))
-  start_date <- as.Date(paste(end_year, 1, 1, sep="-"))
+  end_date <- as.Date(paste(end_year, end_month, 1, sep = "-"))
+  start_date <- as.Date(paste(end_year, 1, 1, sep = "-"))
   
-  ### Create lists with relevant filenames.
-  # NDVI filenames
-  ndvi_files <- get_filenames(filepath = data_path, data_type = data_type, 
+  ndvi_files <- get_filenames(filepath = data_path, data_type = data_type,
                               file_extension = ".tif", country_name = country_name)
   
-  # AoI filenames
-  aoi_files <- get_filenames(filepath = aoi_path, data_type = "AoI", 
+  aoi_files <- get_filenames(filepath = aoi_path, data_type = "AoI",
                              file_extension = ".geojson", country_name = country_name)
   
-  # LULC filenames
-  lulc_files <- get_filenames(filepath = lulc_path, data_type = "LandUseVector", 
+  lulc_files <- get_filenames(filepath = lulc_path, data_type = "LandUseVector",
                               file_extension = ".geojson", country_name = country_name)
   
-  # Get the desired land cover file
-  land_cover_file <- lulc_files[grepl(land_cover_type, lulc_files)][1]
-  
-  ### Subselect filenames according to date
-  # get NDVI filenames dataframe (includes date info)
   files_df <- get_filename_df(ndvi_files = ndvi_files)
   
-  # Given date selected, split file into test data and train data
-  # test filenames
   test_files_df <- filter(files_df, between(dates, start_date, end_date))
   
-  # get train filenames (train interval: prior to test interval start)
   months_in_test <- c(test_files_df$month)
   year_in_test   <- test_files_df$year
-  train_files_df <- files_df %>% 
+  train_files_df <- files_df %>%
     dplyr::filter(month %in% months_in_test & year < year_in_test)
-
-  ### Load raster and vector objects - Aoi, train data and test data
-  # load input Area of Interest (AoI) to later mask data
+  
   aoi_proj <- get_aoi_vector(aoi_files = aoi_files, aoi_path = aoi_path,
-                             projection = "EPSG:4326")
- 
-  land_use <- get_aoi_vector(aoi_files = land_cover_file, aoi_path = lulc_path,
                              projection = "EPSG:4326")
   
   test_ndvi_msk <- get_ndvi_raster(ndvi_files = test_files_df$filenames, data_path = data_path,
@@ -501,48 +477,43 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                     projection = "EPSG:4326", dates = train_files_df$dates,
                                     aoi_proj = aoi_proj)
   
-  test_ndvi_land_use <- mask(test_ndvi_msk, land_use)
+  # AoI-wide historic ribbon (not masked by land cover class)
+  train_ndvi_df_aoi <- get_ndvi_df(ndvi_rast = train_ndvi_msk, dates = train_files_df$dates)
+  train_ndvi_summary_aoi <- get_summary_ndvi_df(ndvi_df = train_ndvi_df_aoi)
   
-  train_ndvi_land_use <- mask(train_ndvi_msk, land_use)
+  land_cover_summaries_list <- vector("list", length(land_cover_classes))
+  names(land_cover_summaries_list) <- land_cover_classes
+  for (lc in land_cover_classes) {
+    land_cover_file <- lulc_files[grepl(lc, lulc_files)][1]
+    if (is.na(land_cover_file) || !nzchar(land_cover_file)) {
+      message("Skipping land cover class ", lc, ": no matching GeoJSON in ", lulc_path)
+      next
+    }
+    land_use_lc <- get_aoi_vector(aoi_files = land_cover_file, aoi_path = lulc_path,
+                                  projection = "EPSG:4326")
+    test_ndvi_lc <- mask(test_ndvi_msk, land_use_lc)
+    train_ndvi_lc <- mask(train_ndvi_msk, land_use_lc)
+    test_ndvi_df_lc <- get_ndvi_df(ndvi_rast = test_ndvi_lc, dates = test_files_df$dates)
+    train_ndvi_df_lc <- get_ndvi_df(ndvi_rast = train_ndvi_lc, dates = train_files_df$dates)
+    test_ndvi_summary_lc <- get_summary_ndvi_df(ndvi_df = test_ndvi_df_lc)
+    train_ndvi_summary_lc <- get_summary_ndvi_df(ndvi_df = train_ndvi_df_lc)
+    land_cover_summaries_list[[lc]] <- dplyr::bind_rows(
+      dplyr::mutate(train_ndvi_summary_lc, land_cover = lc, period = "train"),
+      dplyr::mutate(test_ndvi_summary_lc, land_cover = lc, period = "test")
+    )
+  }
+  land_cover_summaries <- dplyr::bind_rows(land_cover_summaries_list)
   
-  
-  ### Calculate mean NDVI for each month
-  # Extract raster layers for each date
-  # and store in dataframe
-  test_ndvi_df <- get_ndvi_df(ndvi_rast = test_ndvi_land_use, dates = test_files_df$dates) 
-  train_ndvi_df <- get_ndvi_df(ndvi_rast = train_ndvi_land_use, dates = train_files_df$dates) 
-  
-  ## Compute mean, SD, and confidence intervals
-  # test data
-  test_ndvi_summary <- get_summary_ndvi_df(ndvi_df = test_ndvi_df)
-  # train data
-  train_ndvi_summary <- get_summary_ndvi_df(ndvi_df = train_ndvi_df)
-  
-  # Retrieve latest month available in test data for label
-  test_end_month <- test_files_df[max(test_files_df$month),]$dates
-  
-  ## Make plot - distribution of NDVI values throughout the year.
-  ndvi_ts_plot <- plot_ndvi_timeseries(train_data = train_ndvi_summary, 
-                                       test_data = test_ndvi_summary,
-                                       country_name = country_name, 
-                                       resolution = resolution,
-                                       plot_width = 15, 
-                                       plot_height = 8,
-                                       ylim_range = NULL,
-                                       test_start_date = start_date,
-                                       test_end_date = end_date,
-                                       label_test = paste0(land_cover_type, " NDVI ", paste(format(c(start_date, test_end_month), "%b %Y"),collapse=" - ") ),
-                                       label_train = paste0(land_cover_type, " NDVI historic range until ", format(start_date, "%b %Y") ),
-                                       label_mean = paste0(land_cover_type, " NDVI monthly average until ", format(start_date, "%b %Y") ),
-                                       save_path = figures_dir,
-                                       filename = figure_filename
+  name_ribbon <- paste0("Historical range (until ", format(start_date, "%b %Y"), ")")
+  ndvi_ts_plot <- plot_ndvi_landcover_multiline(
+    train_ndvi_summary_aoi = train_ndvi_summary_aoi,
+    land_cover_summaries   = land_cover_summaries,
+    name_ribbon            = name_ribbon
   )
   
-  # if we want to return the ggplot object
-  if (return_plot == TRUE) {
-    
-    return(ndvi_ts_plot)
-    
+  if (isTRUE(return_plot)) {
+    return(list(plot = ndvi_ts_plot))
   }
   
+  invisible(NULL)
 }

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -430,6 +430,7 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                           end_year = NULL, end_month = NULL,
                                           figures_dir = NULL, data_dir = NULL,
                                           return_plot = FALSE, figure_filename = NULL,
+                                          lulc_map_folder_path = NULL,
                                           land_cover_classes = c(
                                             "Crops", "Rangeland", "Water", "Trees",
                                             "Flooded_vegetation", "Built_Area", "Bare_ground"
@@ -505,14 +506,29 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
   land_cover_summaries <- dplyr::bind_rows(land_cover_summaries_list)
   
   name_ribbon <- paste0("Historical range (until ", format(start_date, "%b %Y"), ")")
-  ndvi_ts_plot <- plot_ndvi_landcover_multiline(
-    train_ndvi_summary_aoi = train_ndvi_summary_aoi,
-    land_cover_summaries   = land_cover_summaries,
-    name_ribbon            = name_ribbon
-  )
+  use_map <- !is.null(lulc_map_folder_path) && nzchar(lulc_map_folder_path) &&
+    dir.exists(lulc_map_folder_path)
+  if (isTRUE(use_map)) {
+    combo <- plot_ndvi_landcover_with_map(
+      train_ndvi_summary_aoi = train_ndvi_summary_aoi,
+      land_cover_summaries   = land_cover_summaries,
+      name_ribbon            = name_ribbon,
+      lulc_map_folder        = lulc_map_folder_path,
+      aoi_sf                 = aoi_proj
+    )
+    ndvi_ts_plot <- combo$plot
+    bbox_stem <- combo$bbox_by_stem
+  } else {
+    ndvi_ts_plot <- plot_ndvi_landcover_multiline(
+      train_ndvi_summary_aoi = train_ndvi_summary_aoi,
+      land_cover_summaries   = land_cover_summaries,
+      name_ribbon            = name_ribbon
+    )
+    bbox_stem <- NULL
+  }
   
   if (isTRUE(return_plot)) {
-    return(list(plot = ndvi_ts_plot))
+    return(list(plot = ndvi_ts_plot, bbox_by_stem = bbox_stem))
   }
   
   invisible(NULL)

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -75,7 +75,8 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
   )
   
   if (isTRUE(return_plot)) {
-    return(ndvi_ts_plot)
+    stats <- compute_ndvi_explorer_stats(train_ndvi_df, test_ndvi_df)
+    return(list(plot = ndvi_ts_plot, stats = stats))
   }
   
   invisible(NULL)

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -12,9 +12,6 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
   
   ### Set paths and define parameters
   
-  # figure path
-  figure_path <- file.path(figures_dir, figure_filename)
-  
   data_type <- "NDVI"
   
   # Input NVDI basemaps stored in country folder. 
@@ -71,39 +68,18 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
   test_ndvi_df <- get_ndvi_df(ndvi_rast = test_ndvi_msk, dates = test_files_df$dates) 
   train_ndvi_df <- get_ndvi_df(ndvi_rast = train_ndvi_msk, dates = train_files_df$dates) 
   
-  ## Compute mean, SD, and confidence intervals
-  # test data
-  test_ndvi_summary <- get_summary_ndvi_df(ndvi_df = test_ndvi_df)
-  # train data
-  train_ndvi_summary <- get_summary_ndvi_df(ndvi_df = train_ndvi_df)
-  
-  # Retrieve latest month available in test data for label
-  test_end_month <- test_files_df[max(test_files_df$month),]$dates
-  
-  ## Make plot - distribution of NDVI values throughout the year.
-  ndvi_ts_plot <- plot_ndvi_timeseries(train_data = train_ndvi_summary, 
-                                       test_data = test_ndvi_summary,
-                                       country_name = country_name, 
-                                       resolution = resolution,
-                                       plot_width = 15, 
-                                       plot_height = 8,
-                                       ylim_range = NULL,
-                                       test_start_date = start_date,
-                                       test_end_date = end_date,
-                                       label_test = paste0("NDVI ", paste(format(c(start_date, test_end_month), "%b %Y"),collapse=" - ") ),
-                                       label_train = paste0("NDVI historic range until ", format(start_date, "%b %Y") ),
-                                       label_mean = paste0("NDVI monthly average until ", format(start_date, "%b %Y") ),
-                                       save_path = figures_dir,
-                                       filename = figure_filename
+  ## Interactive plotly: NDVI vs climatology + historic range + monthly anomalies
+  ndvi_ts_plot <- plot_ndvi_anomaly(
+    train_ndvi_df = train_ndvi_df,
+    test_ndvi_df  = test_ndvi_df,
+    resolution    = resolution
   )
   
-  # if we want to return the ggplot object
-  if (return_plot == TRUE) {
-    
+  if (isTRUE(return_plot)) {
     return(ndvi_ts_plot)
-    
   }
   
+  invisible(NULL)
 }
 
 # Function to create Burned Area timeseries plot

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -253,6 +253,44 @@ get_ndvi_df <- function(ndvi_rast = NULL, dates = NULL) {
   return(ndvi_df)
 }
 
+#' Spatial mean NDVI per layer via \code{terra::global} (fast path).
+#'
+#' Returns a small data frame with \code{Year}, \code{Month}, \code{NDVI} per
+#' layer, compatible with \code{get_summary_ndvi_df()} — same inter-annual CI
+#' logic as the pixel-based \code{get_ndvi_df()} path when means match
+#' \code{mean(NDVI, na.rm = TRUE)} over cells.
+#'
+#' @noRd
+get_ndvi_global_means_df <- function(ndvi_rast = NULL, dates = NULL) {
+  if (is.null(ndvi_rast) || is.null(dates)) {
+    stop("ndvi_rast and dates are required.")
+  }
+  nlyr <- terra::nlyr(ndvi_rast)
+  if (nlyr == 0L) {
+    stop("ndvi_rast has no layers.")
+  }
+  if (nlyr != length(dates)) {
+    stop(
+      "Number of raster layers (", nlyr, ") does not match length(dates) (",
+      length(dates), ")."
+    )
+  }
+  dates_key <- if (inherits(dates, "Date")) {
+    dates
+  } else {
+    as.Date(paste0(dates, "-01"))
+  }
+  gm <- terra::global(ndvi_rast, fun = "mean", na.rm = TRUE)
+  vals <- as.numeric(gm[[1L]])
+  data.frame(
+    YearMonth = dates_key,
+    NDVI      = vals,
+    Year      = format(dates_key, "%Y"),
+    Month     = format(dates_key, "%m"),
+    stringsAsFactors = FALSE
+  )
+}
+
 get_ba_df <- function(ba_rast = NULL, dates = NULL) {
   
   # Extract raster layers for each date and store in dataframe

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -327,8 +327,8 @@ lc_plot_mapbox_init_osm <- function() {
   getFromNamespace("geo2cartesian", "plotly")(p)
 }
 
-#' Expand a WGS84 bbox for \code{mapbox.bounds}: enough margin to fit the full AoI in the panel
-#' (wide subplots + title/modebar otherwise clip top/bottom).
+#' Expand a WGS84 bbox for framing the map: enough margin to fit the full AoI in the panel
+#' (used with \code{lc_mapbox_center_zoom_from_bounds}, not as Plotly \code{bounds}, which limits zoom).
 #' @noRd
 lc_mapbox_bounds_from_bbox <- function(xmin, xmax, ymin, ymax,
                                         pad_frac = 0.14,
@@ -357,6 +357,21 @@ lc_mapbox_bounds_from_bbox <- function(xmin, xmax, ymin, ymax,
     south = lat_range[1],
     north = lat_range[2]
   )
+}
+
+#' Initial \code{center} + \code{zoom} for \code{layout.mapbox} (do not set \code{bounds}: in Plotly.js that
+#' restricts pan/zoom like Mapbox \code{maxBounds}, so the wheel cannot zoom out past the study area).
+#' @noRd
+lc_mapbox_center_zoom_from_bounds <- function(west, east, south, north, zoom_pad = 0.45) {
+  lon_c <- (west + east) / 2
+  lat_c <- (south + north) / 2
+  lon_span <- max(east - west, 1e-8)
+  lat_span <- max(north - south, 1e-8)
+  lat_rad <- lat_c * pi / 180
+  span <- max(lat_span, lon_span * abs(cos(lat_rad)))
+  z <- log2(360 / span) - zoom_pad
+  z <- max(1, min(20, z))
+  list(center = list(lon = lon_c, lat = lat_c), zoom = z)
 }
 
 #' Plotly mapbox map (OpenStreetMap) of LULC polygons from a folder; \code{legendgroup} matches NDVI lines.
@@ -458,10 +473,12 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
       max(all_ymax, na.rm = TRUE)
     )
   }
+  cz <- lc_mapbox_center_zoom_from_bounds(bnds$west, bnds$east, bnds$south, bnds$north)
   p <- p %>% plotly::layout(
     mapbox = list(
       style = "open-street-map",
-      bounds = bnds
+      center = cz$center,
+      zoom = cz$zoom
     ),
     margin = list(l = 4, r = 4, t = 24, b = 4),
     title = list(text = "Land cover", font = list(size = 12), y = 0.98, yref = "paper")
@@ -469,7 +486,7 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   list(p = p, bbox_by_stem = bbox_by_stem)
 }
 
-#' NDVI chart beside Plotly mapbox map (two columns); shared \code{legendgroup} links legend to lines + polygons.
+#' NDVI chart above Plotly mapbox map (two rows); shared \code{legendgroup} links legend to lines + polygons.
 #' @param aoi_sf Optional study-area polygon(s); passed to the map layer as a persistent outline.
 #' @noRd
 plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
@@ -490,10 +507,10 @@ plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
   out <- plotly::subplot(
     p_ts,
     mp$p,
-    nrows = 1,
-    widths = c(0.5, 0.5),
-    margin = 0.06,
-    titleY = TRUE
+    nrows = 2,
+    heights = c(0.48, 0.52),
+    margin = 0.08,
+    titleY = FALSE
   )
   out <- out %>%
     plotly::layout(dragmode = "zoom") %>%
@@ -1404,7 +1421,7 @@ landcover_label_to_stem <- function(label, bbox_by_stem) {
   NA_character_
 }
 
-#' Pan combined NDVI+map Plotly figure to a WGS84 bbox (\code{mapbox*.bounds} or legacy \code{geo*}).
+#' Pan combined NDVI+map Plotly figure to a WGS84 bbox (\code{mapbox*.center}/\code{zoom}; legacy \code{geo*}).
 #' @noRd
 lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbox) {
   if (is.null(bbox)) {
@@ -1417,7 +1434,8 @@ lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbo
   if (any(!is.finite(c(xmin, xmax, ymin, ymax)))) {
     return(invisible(NULL))
   }
-  bounds <- lc_mapbox_bounds_from_bbox(xmin, xmax, ymin, ymax)
+  bnds <- lc_mapbox_bounds_from_bbox(xmin, xmax, ymin, ymax)
+  cz <- lc_mapbox_center_zoom_from_bounds(bnds$west, bnds$east, bnds$south, bnds$north, zoom_pad = 0.35)
   pb <- plotly::plotly_build(plot_obj)
   lay <- pb$x$layout
   mb_keys <- grep("^mapbox[0-9]*$", names(lay), value = TRUE)
@@ -1425,13 +1443,15 @@ lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbo
   rl <- list()
   if (length(mb_keys)) {
     gk <- mb_keys[length(mb_keys)]
-    rl[[paste0(gk, ".bounds")]] <- bounds
+    rl[[paste0(gk, ".center")]] <- cz$center
+    rl[[paste0(gk, ".zoom")]] <- cz$zoom
   } else if (length(geo_keys)) {
     gk <- geo_keys[length(geo_keys)]
-    rl[[paste0(gk, ".lonaxis.range")]] <- c(bounds$west, bounds$east)
-    rl[[paste0(gk, ".lataxis.range")]] <- c(bounds$south, bounds$north)
+    rl[[paste0(gk, ".lonaxis.range")]] <- c(bnds$west, bnds$east)
+    rl[[paste0(gk, ".lataxis.range")]] <- c(bnds$south, bnds$north)
   } else {
-    rl[["mapbox2.bounds"]] <- bounds
+    rl[["mapbox2.center"]] <- cz$center
+    rl[["mapbox2.zoom"]] <- cz$zoom
   }
   prx <- plotly::plotlyProxy(plotly_output_id, session)
   plotly::plotlyProxyInvoke(prx, "relayout", rl)

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -1104,11 +1104,27 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     # Transform the GeoJSON data to WGS 84 (EPSG:4326)
     geojson_data <- sf::st_transform(geojson_data, crs = 4326)
     
-    # Add the GeoJSON data to the map with a different color
+    # layerId + group: Shiny Leaflet shape_click identifies the land-cover layer
+    lab_short <- geojson_stem_to_class_key(landuse_type)
+    pop_lab <- if (!is.na(lab_short) && lab_short %in% names(land_cover_class_legend_labels())) {
+      unname(land_cover_class_legend_labels()[[lab_short]])
+    } else {
+      landuse_type
+    }
     map <- map %>%
-      addPolygons(data = geojson_data, color = colors(landuse_type), weight = 2, 
-                  opacity = 0.6, fillOpacity = 0.3, group = landuse_type,
-                  popup = paste("Area (hectares):", round(as.numeric(sf::st_area(geojson_data)) / 10000, 3)))
+      addPolygons(
+        data         = geojson_data,
+        color        = colors(landuse_type),
+        weight       = 2,
+        opacity      = 0.6,
+        fillOpacity  = 0.3,
+        group        = landuse_type,
+        layerId      = rep(landuse_type, nrow(geojson_data)),
+        popup        = paste0(
+          "<strong>", htmltools::htmlEscape(pop_lab), "</strong><br>",
+          "Area (hectares): ", round(as.numeric(sf::st_area(geojson_data)) / 10000, 3)
+        )
+      )
   }
   
   # Add the layers control to the map
@@ -1140,6 +1156,45 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
   
   # Return the map
   return(map)
+}
+
+#' Sync Land Cover Leaflet clicks with Plotly line emphasis (lc_ndvi_plot_output).
+#' @noRd
+lc_landcover_emphasize_plotly_traces <- function(session, plotly_output_id, plot_obj, highlight_label = NULL) {
+  if (is.null(plot_obj)) {
+    return(invisible(NULL))
+  }
+  proxy <- plotly::plotlyProxy(plotly_output_id, session)
+  pb <- plotly::plotly_build(plot_obj)
+  d <- pb$x$data
+  n <- length(d)
+  if (n == 0L) {
+    return(invisible(NULL))
+  }
+  for (ii in seq_len(n)) {
+    idx0 <- ii - 1L
+    tr <- d[[ii]]
+    nm <- tr$name
+    if (is.null(nm) || length(nm) == 0L) {
+      nm <- ""
+    } else {
+      nm <- as.character(nm)[1]
+    }
+    is_ribbon <- grepl("^Historical range", nm)
+    if (is_ribbon) {
+      op <- if (is.null(highlight_label)) 1 else 0.42
+    } else {
+      op <- if (is.null(highlight_label)) {
+        1
+      } else if (identical(nm, highlight_label)) {
+        1
+      } else {
+        0.18
+      }
+    }
+    plotly::plotlyProxyInvoke(proxy, "restyle", list(opacity = op), idx0)
+  }
+  invisible(NULL)
 }
 
 plot_ba_geojson_from_a_folder <- function(input_file_path, data_dir = data_dir, country = country_name, 

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -134,8 +134,43 @@ ndvi_resolution_title_suffix <- function(resolution) {
   )
 }
 
+# Tooltip for NDVI help icon (HTML title attribute; \\n for line breaks in native tooltip).
+ndvi_anomaly_help_tooltip_text <- function() {
+  paste(
+    "NDVI measures how green vegetation is from satellite data.",
+    "Higher values = more vegetation.",
+    "Lower values = less vegetation.",
+    "This chart shows whether current conditions are better or worse than usual.",
+    sep = "\n"
+  )
+}
+
+# Shiny UI: tags$h4 title + tags$span circled-i with native multiline tooltip above plotlyOutput.
+ndvi_anomaly_titles_ui <- function(resolution = NULL) {
+  res_suffix <- ndvi_resolution_title_suffix(resolution)
+  tip <- ndvi_anomaly_help_tooltip_text()
+  icon_style <- paste(
+    "color: #0073e6;",
+    "margin-left: 0.35em;",
+    "cursor: help;"
+  )
+  shiny::tags$div(
+    style = "display: block; width: 100%; box-sizing: border-box;",
+    shiny::tags$h4(
+      style = "text-align: center; margin: 0 0 0.75em 0;",
+      paste0("NDVI Anomaly", res_suffix),
+      shiny::tags$span(
+        title = tip,
+        style = icon_style,
+        "ⓘ"
+      )
+    )
+  )
+}
+
 #' Interactive NDVI time series vs training climatology and historic range (plotly).
-plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolution = NULL) {
+#' Titles with help icon: use ndvi_anomaly_titles_ui() in Shiny above plotlyOutput.
+plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
   train_monthly <- aggregate_monthly_ndvi(train_ndvi_df %>% dplyr::select(YearMonth, NDVI))
   test_monthly  <- aggregate_monthly_ndvi(test_ndvi_df %>% dplyr::select(YearMonth, NDVI))
 
@@ -144,8 +179,6 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
 
   plot_df <- make_anomaly_data(test_monthly, climatology_df) %>%
     dplyr::left_join(historic_range, by = "Month")
-
-  res_suffix <- ndvi_resolution_title_suffix(resolution)
 
   common_xaxis <- list(
     title      = "Month / Year",
@@ -185,11 +218,6 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
       hovertemplate   = "Date: %{x|%b %Y}<br>Historical average: %{y:.3f}<extra></extra>"
     ) %>%
     plotly::layout(
-      title = list(
-        text    = paste0("NDVI Compared with Historical Average", res_suffix),
-        x       = 0.5,
-        xanchor = "center"
-      ),
       xaxis = common_xaxis,
       yaxis = list(title = "NDVI", showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)"),
       template = "plotly_white",
@@ -197,11 +225,11 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
       legend = list(
         orientation = "h",
         x           = 1,
-        y           = 1.18,
+        y           = 1.05,
         xanchor     = "right",
         yanchor     = "top"
       ),
-      margin = list(t = 110, r = 30, l = 60, b = 60)
+      margin = list(t = 50, r = 30, l = 60, b = 60)
     )
 
   p2 <- plotly::plot_ly(
@@ -220,11 +248,6 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
     showlegend = FALSE
   ) %>%
     plotly::layout(
-      title = list(
-        text    = paste0("NDVI Anomaly", res_suffix),
-        x       = 0.5,
-        xanchor = "center"
-      ),
       xaxis = common_xaxis,
       yaxis = list(
         title           = "NDVI Anomaly",
@@ -235,7 +258,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
         gridcolor       = "rgba(0,0,0,0.08)"
       ),
       template = "plotly_white",
-      margin   = list(t = 60, r = 30, l = 60, b = 80)
+      margin   = list(t = 30, r = 30, l = 60, b = 80)
     )
 
   plotly::subplot(
@@ -246,7 +269,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolut
     titleY  = TRUE
   ) %>%
     plotly::layout(
-      margin = list(t = 120, r = 30, l = 60, b = 80)
+      margin = list(t = 20, r = 30, l = 60, b = 80)
     )
 }
 

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -486,7 +486,7 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   list(p = p, bbox_by_stem = bbox_by_stem)
 }
 
-#' NDVI chart above Plotly mapbox map (two rows); shared \code{legendgroup} links legend to lines + polygons.
+#' NDVI chart left, Plotly mapbox map right (two columns); shared \code{legendgroup} links legend to lines + polygons.
 #' @param aoi_sf Optional study-area polygon(s); passed to the map layer as a persistent outline.
 #' @noRd
 plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
@@ -507,10 +507,10 @@ plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
   out <- plotly::subplot(
     p_ts,
     mp$p,
-    nrows = 2,
-    heights = c(0.48, 0.52),
-    margin = 0.08,
-    titleY = FALSE
+    nrows = 1,
+    widths = c(0.5, 0.5),
+    margin = 0.06,
+    titleY = TRUE
   )
   out <- out %>%
     plotly::layout(dragmode = "zoom") %>%

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -327,6 +327,38 @@ lc_plot_mapbox_init_osm <- function() {
   getFromNamespace("geo2cartesian", "plotly")(p)
 }
 
+#' Expand a WGS84 bbox for \code{mapbox.bounds}: enough margin to fit the full AoI in the panel
+#' (wide subplots + title/modebar otherwise clip top/bottom).
+#' @noRd
+lc_mapbox_bounds_from_bbox <- function(xmin, xmax, ymin, ymax,
+                                        pad_frac = 0.14,
+                                        pad_min_deg = 0.0028,
+                                        north_extra_frac = 0.1,
+                                        south_extra_frac = 0.06) {
+  lon_range <- range(c(xmin, xmax))
+  lat_range <- range(c(ymin, ymax))
+  dx <- diff(lon_range)
+  dy <- diff(lat_range)
+  if (!is.finite(dx) || dx < 1e-6) {
+    dx <- 0.05
+  }
+  if (!is.finite(dy) || dy < 1e-6) {
+    dy <- 0.05
+  }
+  pl <- max(dx * pad_frac, pad_min_deg)
+  pb <- max(dy * pad_frac, pad_min_deg)
+  lon_range <- lon_range + c(-1, 1) * pl
+  lat_range <- lat_range + c(-1, 1) * pb
+  lat_range[1] <- lat_range[1] - dy * south_extra_frac
+  lat_range[2] <- lat_range[2] + dy * north_extra_frac
+  list(
+    west  = lon_range[1],
+    east  = lon_range[2],
+    south = lat_range[1],
+    north = lat_range[2]
+  )
+}
+
 #' Plotly mapbox map (OpenStreetMap) of LULC polygons from a folder; \code{legendgroup} matches NDVI lines.
 #' @param aoi_sf Optional study-area polygon(s); non-legend outline under LULC.
 #' @return List with \code{p} (plotly), \code{bbox_by_stem}.
@@ -346,11 +378,13 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   names(bbox_by_stem) <- landuse_types
   p <- lc_plot_mapbox_init_osm()
   all_xmin <- all_xmax <- all_ymin <- all_ymax <- numeric(0)
+  aoi_bbox_for_frame <- NULL
   aoi_ok <- !is.null(aoi_sf) && inherits(aoi_sf, "sf") && nrow(aoi_sf) > 0L &&
     !all(sf::st_is_empty(sf::st_geometry(aoi_sf)))
   if (isTRUE(aoi_ok)) {
     aoi_wgs <- lc_simplify_wgs84_for_plot(sf::st_transform(aoi_sf, 4326))
     bb_aoi <- sf::st_bbox(aoi_wgs)
+    aoi_bbox_for_frame <- bb_aoi
     all_xmin <- c(all_xmin, bb_aoi[["xmin"]])
     all_xmax <- c(all_xmax, bb_aoi[["xmax"]])
     all_ymin <- c(all_ymin, bb_aoi[["ymin"]])
@@ -409,28 +443,25 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
       text = htxt
     )
   }
-  pad <- 0.03
-  lon_range <- range(c(all_xmin, all_xmax))
-  lat_range <- range(c(all_ymin, all_ymax))
-  dx <- diff(lon_range)
-  dy <- diff(lat_range)
-  if (!is.finite(dx) || dx < 1e-6) {
-    dx <- 0.05
+  if (!is.null(aoi_bbox_for_frame)) {
+    bnds <- lc_mapbox_bounds_from_bbox(
+      aoi_bbox_for_frame[["xmin"]],
+      aoi_bbox_for_frame[["xmax"]],
+      aoi_bbox_for_frame[["ymin"]],
+      aoi_bbox_for_frame[["ymax"]]
+    )
+  } else {
+    bnds <- lc_mapbox_bounds_from_bbox(
+      min(all_xmin, na.rm = TRUE),
+      max(all_xmax, na.rm = TRUE),
+      min(all_ymin, na.rm = TRUE),
+      max(all_ymax, na.rm = TRUE)
+    )
   }
-  if (!is.finite(dy) || dy < 1e-6) {
-    dy <- 0.05
-  }
-  lon_range <- lon_range + c(-1, 1) * dx * pad
-  lat_range <- lat_range + c(-1, 1) * dy * pad
   p <- p %>% plotly::layout(
     mapbox = list(
       style = "open-street-map",
-      bounds = list(
-        west  = lon_range[1],
-        east  = lon_range[2],
-        south = lat_range[1],
-        north = lat_range[2]
-      )
+      bounds = bnds
     ),
     margin = list(l = 4, r = 4, t = 24, b = 4),
     title = list(text = "Land cover", font = list(size = 12), y = 0.98, yref = "paper")
@@ -1386,19 +1417,19 @@ lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbo
   if (any(!is.finite(c(xmin, xmax, ymin, ymax)))) {
     return(invisible(NULL))
   }
+  bounds <- lc_mapbox_bounds_from_bbox(xmin, xmax, ymin, ymax)
   pb <- plotly::plotly_build(plot_obj)
   lay <- pb$x$layout
   mb_keys <- grep("^mapbox[0-9]*$", names(lay), value = TRUE)
   geo_keys <- grep("^geo[0-9]*$", names(lay), value = TRUE)
-  bounds <- list(west = xmin, east = xmax, south = ymin, north = ymax)
   rl <- list()
   if (length(mb_keys)) {
     gk <- mb_keys[length(mb_keys)]
     rl[[paste0(gk, ".bounds")]] <- bounds
   } else if (length(geo_keys)) {
     gk <- geo_keys[length(geo_keys)]
-    rl[[paste0(gk, ".lonaxis.range")]] <- c(xmin, xmax)
-    rl[[paste0(gk, ".lataxis.range")]] <- c(ymin, ymax)
+    rl[[paste0(gk, ".lonaxis.range")]] <- c(bounds$west, bounds$east)
+    rl[[paste0(gk, ".lataxis.range")]] <- c(bounds$south, bounds$north)
   } else {
     rl[["mapbox2.bounds"]] <- bounds
   }

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -256,7 +256,7 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
       orientation      = "h",
       x                = 0.5,
       xanchor          = "center",
-      y                = 1.02,
+      y                = 1.08,
       yanchor          = "bottom",
       traceorder       = "normal",
       # ~3 entries per row → 3 wrapped rows for 8 traces (avoids long ribbon vs. class overlap)
@@ -268,7 +268,7 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
       bordercolor      = "rgba(0,0,0,0.08)",
       borderwidth      = 1
     ),
-    margin = list(t = 130, r = 30, l = 60, b = 60)
+    margin = list(t = 118, r = 30, l = 60, b = 60)
   )
 }
 
@@ -279,7 +279,7 @@ ndvi_landcover_titles_ui <- function(resolution = NULL) {
   shiny::tags$div(
     class = "ndvi-anomaly-title-wrap",
     shiny::tags$h4(
-      class = "ndvi-anomaly-title-h4",
+      class = "ndvi-landcover-title-h4",
       paste0("NDVI by land cover", res_suffix)
     )
   )

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -177,12 +177,14 @@ ndvi_insight_smk_tooltip <- function() {
   paste(
     "This result is based on the Seasonal Mann–Kendall test.",
     "It evaluates whether vegetation greenness shows a consistent long-term increase or decrease over multiple years while accounting for seasonal patterns.",
+    "The test is run only when at least 60 monthly samples (5 years) are available.",
     sep = "\n"
   )
 }
 
 #' Wilcoxon (monthly anomalies vs 0) and Seasonal Mann–Kendall on full monthly series.
-#' @return list(wilcox_p, wilcox_median, smk_p, sen_slope)
+#' SMK/Sen run only when there are at least 60 monthly points (5 years).
+#' @return list(wilcox_p, wilcox_median, smk_p, sen_slope, smk_n_months)
 compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
   train_monthly <- aggregate_monthly_ndvi(train_ndvi_df %>% dplyr::select(YearMonth, NDVI))
   test_monthly  <- aggregate_monthly_ndvi(test_ndvi_df %>% dplyr::select(YearMonth, NDVI))
@@ -203,7 +205,9 @@ compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
   ndvi_monthly_full <- dplyr::bind_rows(train_monthly, test_monthly) %>%
     dplyr::distinct(YearMonth, .keep_all = TRUE) %>%
     dplyr::arrange(YearMonth)
-  if (nrow(ndvi_monthly_full) >= 24L) {
+  smk_n_months <- nrow(ndvi_monthly_full)
+  smk_min_months <- 60L
+  if (smk_n_months >= smk_min_months) {
     st <- ndvi_monthly_full$YearMonth[1]
     ndvi_ts <- stats::ts(
       ndvi_monthly_full$NDVI,
@@ -220,7 +224,8 @@ compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
     wilcox_p = wilcox_p,
     wilcox_median = wilcox_median,
     smk_p = smk_p,
-    sen_slope = sen_slope
+    sen_slope = sen_slope,
+    smk_n_months = smk_n_months
   )
 }
 
@@ -283,7 +288,22 @@ ndvi_insight_smk_card_ui <- function(stats) {
   if (is.null(stats)) return(NULL)
   p <- stats$smk_p
   slope <- stats$sen_slope
-  if (is.na(p) || is.na(slope)) {
+  n_m <- stats$smk_n_months
+  if (is.null(n_m) || !is.numeric(n_m)) n_m <- NA_integer_
+  smk_min_months <- 60L
+  if (!is.na(n_m) && n_m < smk_min_months) {
+    main <- "Long-term trend not shown (insufficient series length)"
+    col <- "#555555"
+    p_lab <- paste0(
+      "Seasonal Mann–Kendall applies only with ≥5 years of monthly data (",
+      smk_min_months,
+      " months). Current series: ",
+      n_m,
+      " month",
+      if (n_m == 1L) "" else "s",
+      "."
+    )
+  } else if (is.na(p) || is.na(slope)) {
     main <- "Long-term trend cannot be assessed from this series"
     col <- "#555555"
     p_lab <- "p-value: N/A"

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -138,8 +138,8 @@ ndvi_resolution_title_suffix <- function(resolution) {
 ndvi_anomaly_help_tooltip_text <- function() {
   paste(
     "NDVI measures how green vegetation is from satellite data.",
-    "Higher values = more vegetation.",
-    "Lower values = less vegetation.",
+    "Higher values (max 1) = more vegetation.",
+    "Lower values (min -1) = less vegetation.",
     "This chart shows whether current conditions are better or worse than usual.",
     sep = "\n"
   )
@@ -337,7 +337,15 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
   historic_range   <- get_monthly_historic_range(train_monthly)
 
   plot_df <- make_anomaly_data(test_monthly, climatology_df) %>%
-    dplyr::left_join(historic_range, by = "Month")
+    dplyr::left_join(historic_range, by = "Month") %>%
+    dplyr::mutate(
+      hover_bar = paste0(
+        "Date: ", format(YearMonth, "%b %Y"), "<br>",
+        "Anomaly: ", sprintf("%.3f", anomaly), "<br>",
+        "Current NDVI: ", sprintf("%.3f", NDVI), "<br>",
+        "Historical average: ", sprintf("%.3f", climatology)
+      )
+    )
 
   common_xaxis <- list(
     title      = "Month / Year",
@@ -397,13 +405,9 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
     y       = ~anomaly,
     type    = "bar",
     marker  = list(color = plot_df$bar_color),
-    customdata = ~cbind(NDVI, climatology),
-    hovertemplate = paste0(
-      "Date: %{x|%b %Y}<br>",
-      "Anomaly: %{y:.3f}<br>",
-      "Current NDVI: %{customdata[0]:.3f}<br>",
-      "Historical average: %{customdata[1]:.3f}<extra></extra>"
-    ),
+    text    = ~hover_bar,
+    textposition = "none",
+    hovertemplate = "%{text}<extra></extra>",
     showlegend = FALSE
   ) %>%
     plotly::layout(

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -168,6 +168,165 @@ ndvi_anomaly_titles_ui <- function(resolution = NULL) {
   )
 }
 
+# --- NDVI Explorer insight cards (Wilcoxon + Seasonal Mann–Kendall) -----------------
+
+ndvi_insight_wilcox_tooltip <- function() {
+  paste(
+    "This result is based on a Wilcoxon signed-rank test applied to monthly NDVI anomalies for the selected year.",
+    "It checks whether vegetation conditions in the selected year are significantly different from the historical monthly average.",
+    sep = "\n"
+  )
+}
+
+ndvi_insight_smk_tooltip <- function() {
+  paste(
+    "This result is based on the Seasonal Mann–Kendall test.",
+    "It evaluates whether vegetation greenness shows a consistent long-term increase or decrease over multiple years while accounting for seasonal patterns.",
+    sep = "\n"
+  )
+}
+
+#' Wilcoxon (monthly anomalies vs 0) and Seasonal Mann–Kendall on full monthly series.
+#' @return list(wilcox_p, wilcox_median, smk_p, sen_slope)
+compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
+  train_monthly <- aggregate_monthly_ndvi(train_ndvi_df %>% dplyr::select(YearMonth, NDVI))
+  test_monthly  <- aggregate_monthly_ndvi(test_ndvi_df %>% dplyr::select(YearMonth, NDVI))
+  climatology_df <- get_monthly_climatology(train_monthly)
+  plot_df <- make_anomaly_data(test_monthly, climatology_df)
+
+  anom <- stats::na.omit(plot_df$anomaly)
+  wilcox_p <- NA_real_
+  wilcox_median <- NA_real_
+  if (length(anom) >= 3L) {
+    wt <- stats::wilcox.test(anom, mu = 0)
+    wilcox_p <- unname(wt$p.value)
+    wilcox_median <- stats::median(anom)
+  }
+
+  smk_p <- NA_real_
+  sen_slope <- NA_real_
+  ndvi_monthly_full <- dplyr::bind_rows(train_monthly, test_monthly) %>%
+    dplyr::distinct(YearMonth, .keep_all = TRUE) %>%
+    dplyr::arrange(YearMonth)
+  if (nrow(ndvi_monthly_full) >= 24L) {
+    st <- ndvi_monthly_full$YearMonth[1]
+    ndvi_ts <- stats::ts(
+      ndvi_monthly_full$NDVI,
+      start = c(lubridate::year(st), lubridate::month(st)),
+      frequency = 12
+    )
+    smk <- tryCatch(trend::smk.test(ndvi_ts), error = function(e) NULL)
+    sen <- tryCatch(trend::sens.slope(ndvi_ts), error = function(e) NULL)
+    if (!is.null(smk)) smk_p <- unname(smk$p.value)
+    if (!is.null(sen)) sen_slope <- as.numeric(sen$estimates)[1]
+  }
+
+  list(
+    wilcox_p = wilcox_p,
+    wilcox_median = wilcox_median,
+    smk_p = smk_p,
+    sen_slope = sen_slope
+  )
+}
+
+ndvi_insight_card_base_style <- function() {
+  "background: #f8f9fa; border: 1px solid #e0e0e0; border-radius: 10px; padding: 15px; height: 100%; box-sizing: border-box;"
+}
+
+ndvi_insight_icon_style <- function() {
+  "color: #0073e6; margin-left: 0.35em; cursor: help;"
+}
+
+#' Shiny UI: Current Year Condition card (uses compute_ndvi_explorer_stats output).
+ndvi_insight_wilcox_card_ui <- function(stats) {
+  if (is.null(stats)) return(NULL)
+  p <- stats$wilcox_p
+  med <- stats$wilcox_median
+  icon_st <- ndvi_insight_icon_style()
+  if (is.na(p)) {
+    main <- "Not enough data for this summary"
+    col <- "#555555"
+    p_lab <- "p-value: N/A"
+  } else if (!is.na(p) && p < 0.05 && !is.na(med) && med > 0) {
+    main <- "Above normal vegetation"
+    col <- "#009E73"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  } else if (!is.na(p) && p < 0.05 && !is.na(med) && med < 0) {
+    main <- "Below normal vegetation"
+    col <- "#D55E00"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  } else {
+    main <- "No significant difference from normal"
+    col <- "#555555"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  }
+  shiny::tags$div(
+    style = ndvi_insight_card_base_style(),
+    shiny::tags$h4(
+      style = "font-size: 16px; margin: 0 0 12px 0; font-weight: 600;",
+      "Current Year Condition",
+      shiny::tags$span(
+        title = ndvi_insight_wilcox_tooltip(),
+        style = icon_st,
+        "ⓘ"
+      )
+    ),
+    shiny::tags$div(
+      style = paste0("font-size: 20px; font-weight: bold; color: ", col, "; line-height: 1.3;"),
+      main
+    ),
+    shiny::tags$div(
+      style = "font-size: 13px; color: #666; margin-top: 10px;",
+      p_lab
+    )
+  )
+}
+
+#' Shiny UI: Long-Term Trend card (Seasonal Mann–Kendall + Sen slope sign).
+ndvi_insight_smk_card_ui <- function(stats) {
+  if (is.null(stats)) return(NULL)
+  p <- stats$smk_p
+  slope <- stats$sen_slope
+  icon_st <- ndvi_insight_icon_style()
+  if (is.na(p) || is.na(slope)) {
+    main <- "Long-term trend cannot be assessed from this series"
+    col <- "#555555"
+    p_lab <- "p-value: N/A"
+  } else if (p < 0.05 && slope > 0) {
+    main <- "Significant increasing trend"
+    col <- "#009E73"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  } else if (p < 0.05 && slope < 0) {
+    main <- "Significant decreasing trend"
+    col <- "#D55E00"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  } else {
+    main <- "No significant long-term trend"
+    col <- "#555555"
+    p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
+  }
+  shiny::tags$div(
+    style = ndvi_insight_card_base_style(),
+    shiny::tags$h4(
+      style = "font-size: 16px; margin: 0 0 12px 0; font-weight: 600;",
+      "Long-Term Trend",
+      shiny::tags$span(
+        title = ndvi_insight_smk_tooltip(),
+        style = icon_st,
+        "ⓘ"
+      )
+    ),
+    shiny::tags$div(
+      style = paste0("font-size: 20px; font-weight: bold; color: ", col, "; line-height: 1.3;"),
+      main
+    ),
+    shiny::tags$div(
+      style = "font-size: 13px; color: #666; margin-top: 10px;",
+      p_lab
+    )
+  )
+}
+
 #' Interactive NDVI time series vs training climatology and historic range (plotly).
 #' Titles with help icon: use ndvi_anomaly_titles_ui() in Shiny above plotlyOutput.
 plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -518,6 +518,32 @@ plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
   list(plot = out, bbox_by_stem = mp$bbox_by_stem)
 }
 
+#' Land cover seasonal-pattern table (real DOM; works in Chrome without JS tooltip HTML quirks).
+#' @noRd
+lc_land_cover_explorer_tooltip_table_tags <- function() {
+  row <- function(a, b) {
+    shiny::tags$tr(shiny::tags$td(a), shiny::tags$td(b))
+  }
+  shiny::tags$table(
+    class = "lc-landcover-tooltip-table",
+    shiny::tags$thead(
+      shiny::tags$tr(
+        shiny::tags$th("Land cover"),
+        shiny::tags$th("Seasonal pattern")
+      )
+    ),
+    shiny::tags$tbody(
+      row("Trees", "Highest NDVI. Stable year-round, peaks in rainy season (Feb–Mar)."),
+      row("Rangeland", "Seasonal — rises with rainfall, drops in dry season."),
+      row("Crops", "Sharp rise at planting (Nov–Dec), drops at harvest (May–Jun)."),
+      row("Flooded vegetation", "Low when flooded early in year, rises as water recedes."),
+      row("Bare ground", "Lowest NDVI. Slight rise after rain due to sparse vegetation."),
+      row("Built area", "Low and stable — built surfaces don't respond to rainfall."),
+      row("Water", "Near-zero NDVI. Higher values indicate riverside mixed pixels.")
+    )
+  )
+}
+
 #' Shiny UI: title row above Land Cover Plotly chart.
 #' @param year Calendar year of the test NDVI series (same as server \code{end_year}); optional.
 #' @noRd
@@ -531,8 +557,18 @@ ndvi_landcover_titles_ui <- function(resolution = NULL, year = NULL) {
   shiny::tags$div(
     class = "ndvi-anomaly-title-wrap",
     shiny::tags$h4(
-      class = "ndvi-landcover-title-h4",
-      paste0("NDVI by land cover", res_suffix, yr_part)
+      class = "ndvi-anomaly-title-h4 ndvi-landcover-title-h4",
+      paste0("NDVI by land cover", res_suffix, yr_part),
+      shiny::tags$span(
+        class = "lc-landcover-tooltip-wrap",
+        tabindex = "0",
+        shiny::tags$span(class = "ndvi-help-icon", `aria-label` = "Land cover seasonal patterns", "ⓘ"),
+        shiny::tags$div(
+          class = "lc-landcover-tooltip-panel",
+          role = "tooltip",
+          lc_land_cover_explorer_tooltip_table_tags()
+        )
+      )
     )
   )
 }

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -273,14 +273,20 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
 }
 
 #' Shiny UI: title row above Land Cover Plotly chart.
+#' @param year Calendar year of the test NDVI series (same as server \code{end_year}); optional.
 #' @noRd
-ndvi_landcover_titles_ui <- function(resolution = NULL) {
+ndvi_landcover_titles_ui <- function(resolution = NULL, year = NULL) {
   res_suffix <- ndvi_resolution_title_suffix(resolution)
+  yr_part <- if (!is.null(year)) {
+    paste0(", ", as.integer(year))
+  } else {
+    ""
+  }
   shiny::tags$div(
     class = "ndvi-anomaly-title-wrap",
     shiny::tags$h4(
       class = "ndvi-landcover-title-h4",
-      paste0("NDVI by land cover", res_suffix)
+      paste0("NDVI by land cover", res_suffix, yr_part)
     )
   )
 }

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -105,6 +105,25 @@ land_cover_class_keys_ordered <- function() {
   names(land_cover_class_colors())
 }
 
+#' Convert \code{#RRGGBB} to \code{rgba(...)} for Plotly map polygons.
+#' Eight-digit hex (\code{#RRGGBBAA}) is unreliable for \code{scattermapbox} \code{fillcolor}
+#' in the browser; outlines still use \code{line.color}.
+#' @noRd
+lc_hex_to_rgba <- function(hex, alpha = 0.55) {
+  hex <- trimws(hex)
+  if (!grepl("^#", hex)) {
+    return(sprintf("rgba(128,128,128,%g)", alpha))
+  }
+  h <- substr(hex, 2, 7)
+  if (nchar(h) != 6L) {
+    return(sprintf("rgba(128,128,128,%g)", alpha))
+  }
+  r <- strtoi(substr(h, 1, 2), 16L)
+  g <- strtoi(substr(h, 3, 4), 16L)
+  b <- strtoi(substr(h, 5, 6), 16L)
+  sprintf("rgba(%d,%d,%d,%g)", r, g, b, alpha)
+}
+
 #' Map a GeoJSON filename stem (e.g. \code{Zambia_Mponda_Crops_2023}) to a class key.
 #' @noRd
 geojson_stem_to_class_key <- function(stem) {
@@ -277,10 +296,40 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
   )
 }
 
-#' Plotly geo map of LULC polygons from the same GeoJSON folder as Leaflet; \code{legendgroup} matches NDVI lines.
-#' @param aoi_sf Optional study-area polygon(s) in any CRS; drawn as a non-legend outline under LULC so the map
-#'   is not empty when all classes are toggled off.
-#' @return List with \code{p} (plotly), \code{bbox_by_stem} (named list of bboxes).
+#' Lightly simplify geometries for Plotly (fewer vertices, faster client rendering).
+#' Uses metre tolerance on geographic CRS when sf S2 is enabled; otherwise degree tolerance.
+#' @noRd
+lc_simplify_wgs84_for_plot <- function(x, dTolerance_m = 75, dTolerance_deg = 0.00025) {
+  if (!inherits(x, "sf") || nrow(x) == 0L) {
+    return(x)
+  }
+  g <- sf::st_geometry(x)
+  if (all(sf::st_is_empty(g))) {
+    return(x)
+  }
+  dtol <- if (isTRUE(sf::sf_use_s2()) && sf::st_is_longlat(x)) dTolerance_m else dTolerance_deg
+  sg <- tryCatch(
+    sf::st_simplify(g, dTolerance = dtol, preserveTopology = TRUE),
+    error = function(e) g
+  )
+  sf::st_set_geometry(x, sg)
+}
+
+#' Empty mapbox figure for \code{add_sf} without \code{plot_mapbox()} (avoids MAPBOX_TOKEN error for OSM).
+#' \code{plot_mapbox()} calls \code{mapbox_token()}; open-street-map tiles work in the browser without a token.
+#' @noRd
+lc_plot_mapbox_init_osm <- function() {
+  p <- plotly::plot_ly()
+  if (is.null(p$x$layout)) {
+    p$x$layout <- list()
+  }
+  p$x$layout$mapType <- "mapbox"
+  getFromNamespace("geo2cartesian", "plotly")(p)
+}
+
+#' Plotly mapbox map (OpenStreetMap) of LULC polygons from a folder; \code{legendgroup} matches NDVI lines.
+#' @param aoi_sf Optional study-area polygon(s); non-legend outline under LULC.
+#' @return List with \code{p} (plotly), \code{bbox_by_stem}.
 #' @noRd
 plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   message(paste("Plotting LULC GeoJSON for Plotly map:", folder_path))
@@ -295,12 +344,12 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   pal_named <- land_cover_class_colors()
   bbox_by_stem <- vector("list", length(landuse_types))
   names(bbox_by_stem) <- landuse_types
-  p <- plotly::plot_ly()
+  p <- lc_plot_mapbox_init_osm()
   all_xmin <- all_xmax <- all_ymin <- all_ymax <- numeric(0)
   aoi_ok <- !is.null(aoi_sf) && inherits(aoi_sf, "sf") && nrow(aoi_sf) > 0L &&
     !all(sf::st_is_empty(sf::st_geometry(aoi_sf)))
   if (isTRUE(aoi_ok)) {
-    aoi_wgs <- sf::st_transform(aoi_sf, 4326)
+    aoi_wgs <- lc_simplify_wgs84_for_plot(sf::st_transform(aoi_sf, 4326))
     bb_aoi <- sf::st_bbox(aoi_wgs)
     all_xmin <- c(all_xmin, bb_aoi[["xmin"]])
     all_xmax <- c(all_xmax, bb_aoi[["xmax"]])
@@ -311,6 +360,8 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
       inherit = FALSE,
       name = "Study area",
       showlegend = FALSE,
+      fill = "toself",
+      mode = "lines",
       fillcolor = "rgba(0,0,0,0)",
       line = list(color = "#222222", width = 2),
       hoverinfo = "text",
@@ -320,7 +371,7 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   for (i in seq_along(geojson_files)) {
     stem <- landuse_types[i]
     geojson_data <- sf::st_read(geojson_files[i], quiet = TRUE)
-    geojson_data <- sf::st_transform(geojson_data, crs = 4326)
+    geojson_data <- lc_simplify_wgs84_for_plot(sf::st_transform(geojson_data, crs = 4326))
     bbox_by_stem[[stem]] <- sf::st_bbox(geojson_data)
     lab_short <- geojson_stem_to_class_key(stem)
     pop_lab <- if (!is.na(lab_short) && lab_short %in% names(land_cover_class_legend_labels())) {
@@ -350,7 +401,9 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
       name = pop_lab,
       legendgroup = lg,
       showlegend = FALSE,
-      fillcolor = paste0(col, "99"),
+      fill = "toself",
+      mode = "lines",
+      fillcolor = lc_hex_to_rgba(col, alpha = 0.55),
       line = list(color = col, width = 2),
       hoverinfo = "text",
       text = htxt
@@ -370,18 +423,16 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   lon_range <- lon_range + c(-1, 1) * dx * pad
   lat_range <- lat_range + c(-1, 1) * dy * pad
   p <- p %>% plotly::layout(
-    geo = list(
-      scope = "world",
-      projection = list(type = "mercator"),
-      lonaxis = list(range = lon_range),
-      lataxis = list(range = lat_range),
-      showland = TRUE,
-      landcolor = "rgb(245,245,245)",
-      showocean = TRUE,
-      oceancolor = "rgb(220,235,245)",
-      bgcolor = "rgba(255,255,255,0)"
+    mapbox = list(
+      style = "open-street-map",
+      bounds = list(
+        west  = lon_range[1],
+        east  = lon_range[2],
+        south = lat_range[1],
+        north = lat_range[2]
+      )
     ),
-    margin = list(l = 8, r = 8, t = 28, b = 8),
+    margin = list(l = 4, r = 4, t = 24, b = 4),
     title = list(text = "Land cover", font = list(size = 12), y = 0.98, yref = "paper")
   )
   list(p = p, bbox_by_stem = bbox_by_stem)
@@ -1322,7 +1373,7 @@ landcover_label_to_stem <- function(label, bbox_by_stem) {
   NA_character_
 }
 
-#' Pan combined NDVI+map Plotly figure to a WGS84 bbox (uses layout \code{geo*} from \code{plotly_build}).
+#' Pan combined NDVI+map Plotly figure to a WGS84 bbox (\code{mapbox*.bounds} or legacy \code{geo*}).
 #' @noRd
 lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbox) {
   if (is.null(bbox)) {
@@ -1337,11 +1388,20 @@ lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbo
   }
   pb <- plotly::plotly_build(plot_obj)
   lay <- pb$x$layout
+  mb_keys <- grep("^mapbox[0-9]*$", names(lay), value = TRUE)
   geo_keys <- grep("^geo[0-9]*$", names(lay), value = TRUE)
-  gk <- if (length(geo_keys)) geo_keys[length(geo_keys)] else "geo"
+  bounds <- list(west = xmin, east = xmax, south = ymin, north = ymax)
   rl <- list()
-  rl[[paste0(gk, ".lonaxis.range")]] <- c(xmin, xmax)
-  rl[[paste0(gk, ".lataxis.range")]] <- c(ymin, ymax)
+  if (length(mb_keys)) {
+    gk <- mb_keys[length(mb_keys)]
+    rl[[paste0(gk, ".bounds")]] <- bounds
+  } else if (length(geo_keys)) {
+    gk <- geo_keys[length(geo_keys)]
+    rl[[paste0(gk, ".lonaxis.range")]] <- c(xmin, xmax)
+    rl[[paste0(gk, ".lataxis.range")]] <- c(ymin, ymax)
+  } else {
+    rl[["mapbox2.bounds"]] <- bounds
+  }
   prx <- plotly::plotlyProxy(plotly_output_id, session)
   plotly::plotlyProxyInvoke(prx, "relayout", rl)
   invisible(NULL)
@@ -1363,6 +1423,15 @@ lc_landcover_emphasize_plotly_traces <- function(session, plotly_output_id, plot
   for (ii in seq_len(n)) {
     idx0 <- ii - 1L
     tr <- d[[ii]]
+    ttype <- tr[["type"]]
+    if (is.null(ttype)) {
+      ttype <- ""
+    } else {
+      ttype <- as.character(ttype)[1]
+    }
+    if (ttype %in% c("scattermapbox", "scattergeo")) {
+      next
+    }
     nm <- tr$name
     if (is.null(nm) || length(nm) == 0L) {
       nm <- ""

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -17,7 +17,7 @@ plot_ndvi_timeseries <- function(train_data = NULL, test_data = NULL,
   
   # Set y value range for plot
   if (is.null(ylim_range)) {
-    ylim_range <- c(min(train_data$upper_ci)-0.25, max(train_data$upper_ci)+0.15)
+    ylim_range <- c(min(train_data$upper_ci) - 0.25, max(train_data$upper_ci) + 0.15)
   }
   
   # Add Month Name to dataframes
@@ -81,6 +81,173 @@ plot_ndvi_timeseries <- function(train_data = NULL, test_data = NULL,
   
   # Return the plot
   return(ts_plot)
+}
+
+# --- NDVI anomaly (Plotly): monthly NDVI vs climatology + historic min/max band ----
+
+aggregate_monthly_ndvi <- function(df) {
+  df %>%
+    dplyr::mutate(YearMonth = as.Date(YearMonth)) %>%
+    dplyr::filter(!is.na(YearMonth), !is.na(NDVI)) %>%
+    dplyr::group_by(YearMonth) %>%
+    dplyr::summarise(NDVI = mean(NDVI, na.rm = TRUE), .groups = "drop") %>%
+    dplyr::arrange(YearMonth) %>%
+    dplyr::mutate(
+      Year  = lubridate::year(YearMonth),
+      Month = lubridate::month(YearMonth)
+    )
+}
+
+get_monthly_climatology <- function(train_df) {
+  train_df %>%
+    dplyr::group_by(Month) %>%
+    dplyr::summarise(climatology = mean(NDVI, na.rm = TRUE), .groups = "drop")
+}
+
+get_monthly_historic_range <- function(train_monthly) {
+  train_monthly %>%
+    dplyr::group_by(Month) %>%
+    dplyr::summarise(
+      lower = min(NDVI, na.rm = TRUE),
+      upper = max(NDVI, na.rm = TRUE),
+      .groups = "drop"
+    )
+}
+
+make_anomaly_data <- function(test_df, climatology_df) {
+  test_df %>%
+    dplyr::left_join(climatology_df, by = "Month") %>%
+    dplyr::mutate(
+      anomaly   = NDVI - climatology,
+      bar_color = ifelse(anomaly >= 0, "#009E73", "#D55E00")
+    )
+}
+
+ndvi_resolution_title_suffix <- function(resolution) {
+  if (is.null(resolution) || !nzchar(as.character(resolution))) {
+    return("")
+  }
+  paste0(
+    " (",
+    ifelse(grepl("_", resolution), sub(".*_", "", resolution), resolution),
+    "m res)"
+  )
+}
+
+#' Interactive NDVI time series vs training climatology and historic range (plotly).
+plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL, resolution = NULL) {
+  train_monthly <- aggregate_monthly_ndvi(train_ndvi_df %>% dplyr::select(YearMonth, NDVI))
+  test_monthly  <- aggregate_monthly_ndvi(test_ndvi_df %>% dplyr::select(YearMonth, NDVI))
+
+  climatology_df <- get_monthly_climatology(train_monthly)
+  historic_range   <- get_monthly_historic_range(train_monthly)
+
+  plot_df <- make_anomaly_data(test_monthly, climatology_df) %>%
+    dplyr::left_join(historic_range, by = "Month")
+
+  res_suffix <- ndvi_resolution_title_suffix(resolution)
+
+  common_xaxis <- list(
+    title      = "Month / Year",
+    tickmode   = "linear",
+    dtick      = "M1",
+    tickformat = "%b %Y",
+    tickangle  = -45,
+    showgrid   = FALSE
+  )
+
+  p1 <- plotly::plot_ly() %>%
+    plotly::add_ribbons(
+      data      = plot_df,
+      x         = ~YearMonth,
+      ymin      = ~lower,
+      ymax      = ~upper,
+      name      = "NDVI historic range (train)",
+      legendgroup = "historic",
+      fillcolor = "rgba(39, 129, 207, 0.2)",
+      line      = list(color = "transparent"),
+      hoverinfo = "skip"
+    ) %>%
+    plotly::add_lines(
+      data            = plot_df,
+      x               = ~YearMonth, y = ~NDVI,
+      type            = "scatter", mode = "lines+markers",
+      name            = "Current NDVI",
+      line            = list(width = 3, color = "#0072B2"),
+      marker          = list(size = 7, color = "#0072B2"),
+      hovertemplate   = "Date: %{x|%b %Y}<br>NDVI: %{y:.3f}<extra></extra>"
+    ) %>%
+    plotly::add_lines(
+      data            = plot_df,
+      x               = ~YearMonth, y = ~climatology,
+      name            = "Historical monthly average",
+      line            = list(width = 2.5, dash = "dash", color = "#E69F00"),
+      hovertemplate   = "Date: %{x|%b %Y}<br>Historical average: %{y:.3f}<extra></extra>"
+    ) %>%
+    plotly::layout(
+      title = list(
+        text    = paste0("NDVI Compared with Historical Average", res_suffix),
+        x       = 0.5,
+        xanchor = "center"
+      ),
+      xaxis = common_xaxis,
+      yaxis = list(title = "NDVI", showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)"),
+      template = "plotly_white",
+      hovermode  = "x unified",
+      legend = list(
+        orientation = "h",
+        x           = 1,
+        y           = 1.18,
+        xanchor     = "right",
+        yanchor     = "top"
+      ),
+      margin = list(t = 110, r = 30, l = 60, b = 60)
+    )
+
+  p2 <- plotly::plot_ly(
+    data    = plot_df,
+    x       = ~YearMonth,
+    y       = ~anomaly,
+    type    = "bar",
+    marker  = list(color = plot_df$bar_color),
+    customdata = ~cbind(NDVI, climatology),
+    hovertemplate = paste0(
+      "Date: %{x|%b %Y}<br>",
+      "Anomaly: %{y:.3f}<br>",
+      "Current NDVI: %{customdata[0]:.3f}<br>",
+      "Historical average: %{customdata[1]:.3f}<extra></extra>"
+    ),
+    showlegend = FALSE
+  ) %>%
+    plotly::layout(
+      title = list(
+        text    = paste0("NDVI Anomaly", res_suffix),
+        x       = 0.5,
+        xanchor = "center"
+      ),
+      xaxis = common_xaxis,
+      yaxis = list(
+        title           = "NDVI Anomaly",
+        zeroline        = TRUE,
+        zerolinewidth   = 2,
+        zerolinecolor   = "gray50",
+        showgrid        = TRUE,
+        gridcolor       = "rgba(0,0,0,0.08)"
+      ),
+      template = "plotly_white",
+      margin   = list(t = 60, r = 30, l = 60, b = 80)
+    )
+
+  plotly::subplot(
+    p1, p2,
+    nrows   = 2,
+    shareX  = TRUE,
+    heights = c(0.58, 0.42),
+    titleY  = TRUE
+  ) %>%
+    plotly::layout(
+      margin = list(t = 120, r = 30, l = 60, b = 80)
+    )
 }
 
 # Function to plot Burned Area distribution

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -83,6 +83,208 @@ plot_ndvi_timeseries <- function(train_data = NULL, test_data = NULL,
   return(ts_plot)
 }
 
+# --- Land cover: shared colors (Leaflet map + Plotly time series) --------------------
+
+#' Named hex colors for canonical LULC class keys (aligned with map palette).
+#' @noRd
+land_cover_class_colors <- function() {
+  c(
+    Bare_ground        = "#EDE9E4",
+    Built_Area         = "#ED022A",
+    Crops              = "#FFDB5C",
+    Flooded_vegetation = "#87D19E",
+    Rangeland          = "#A7D282",
+    Trees              = "#358221",
+    Water              = "#1A5BAB"
+  )
+}
+
+#' Stable iteration order for loops / legend (matches \code{land_cover_class_colors} names).
+#' @noRd
+land_cover_class_keys_ordered <- function() {
+  names(land_cover_class_colors())
+}
+
+#' Map a GeoJSON filename stem (e.g. \code{Zambia_Mponda_Crops_2023}) to a class key.
+#' @noRd
+geojson_stem_to_class_key <- function(stem) {
+  keys <- land_cover_class_keys_ordered()
+  keys_by_len <- keys[order(-nchar(keys), keys)]
+  for (k in keys_by_len) {
+    if (grepl(k, stem, fixed = TRUE)) {
+      return(k)
+    }
+  }
+  NA_character_
+}
+
+#' Human-readable legend labels for class keys.
+#' @noRd
+land_cover_class_legend_labels <- function() {
+  c(
+    Bare_ground        = "Bare ground",
+    Built_Area         = "Built area",
+    Crops              = "Crops",
+    Flooded_vegetation = "Flooded vegetation",
+    Rangeland          = "Rangeland",
+    Trees              = "Trees",
+    Water              = "Water"
+  )
+}
+
+#' Multi-line Plotly NDVI by land cover + AoI historic CI ribbon (NDVI TS–style layout).
+#' @noRd
+plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
+                                          land_cover_summaries = NULL,
+                                          name_ribbon = "Historical range") {
+  # Extra padding + absolute margin so ribbon CIs and sharp dips stay inside the frame.
+  pad_y_range <- function(lo, hi, pad = 0.14, abs_margin = 0.035) {
+    if (!is.finite(lo) || !is.finite(hi)) {
+      return(NULL)
+    }
+    if (lo > hi) {
+      return(NULL)
+    }
+    if (abs(hi - lo) < 1e-9) {
+      pad_abs <- max(0.05, abs(lo) * 0.08 + 0.02)
+      return(c(lo - pad_abs, hi + pad_abs))
+    }
+    span <- hi - lo
+    low  <- lo - pad * span - abs_margin
+    high <- hi + pad * span + abs_margin
+    # Keep axis within plausible NDVI bounds while preserving headroom
+    low  <- max(-1.05, low)
+    high <- min(1.05, high)
+    if (low >= high) {
+      return(NULL)
+    }
+    c(low, high)
+  }
+
+  lc_colors <- land_cover_class_colors()
+  lc_labels <- land_cover_class_legend_labels()
+
+  ribbon_df <- train_ndvi_summary_aoi %>%
+    dplyr::mutate(
+      month_int   = as.integer(Month),
+      month_label = month.name[month_int],
+      month_label = factor(month_label, levels = month.name)
+    ) %>%
+    dplyr::filter(!is.na(month_label))
+
+  test_df <- land_cover_summaries %>%
+    dplyr::filter(period == "test") %>%
+    dplyr::mutate(
+      land_cover  = as.character(land_cover),
+      month_int   = as.integer(Month),
+      month_label = month.name[month_int],
+      month_label = factor(month_label, levels = month.name)
+    ) %>%
+    dplyr::filter(!is.na(month_label))
+
+  vals_y <- c(ribbon_df$lower_ci, ribbon_df$upper_ci, test_df$mean_val)
+  vals_y <- vals_y[is.finite(vals_y)]
+  rng_ndvi <- if (length(vals_y)) {
+    pad_y_range(min(vals_y), max(vals_y))
+  } else {
+    NULL
+  }
+
+  ndvi_y_axis <- list(title = "Mean NDVI", showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)")
+  if (!is.null(rng_ndvi)) {
+    ndvi_y_axis$range <- rng_ndvi
+    ndvi_y_axis$autorange <- FALSE
+  }
+
+  xaxis <- list(
+    title          = "Month",
+    type           = "category",
+    categoryorder  = "array",
+    categoryarray  = month.name,
+    showgrid       = FALSE
+  )
+
+  p <- plotly::plot_ly() %>%
+    plotly::add_ribbons(
+      data        = ribbon_df,
+      x           = ~month_label,
+      ymin        = ~lower_ci,
+      ymax        = ~upper_ci,
+      name        = name_ribbon,
+      legendgroup = "baseline",
+      fillcolor   = "rgba(39, 129, 207, 0.2)",
+      line        = list(color = "transparent"),
+      hoverinfo   = "skip"
+    )
+
+  for (lc in land_cover_class_keys_ordered()) {
+    sub <- test_df %>% dplyr::filter(land_cover == lc)
+    if (nrow(sub) == 0) {
+      next
+    }
+    col <- unname(lc_colors[lc])
+    if (is.na(col)) {
+      next
+    }
+    lab <- unname(lc_labels[lc])
+    sub <- sub %>% dplyr::mutate(
+      hover_line = paste0(
+        lab, "<br>",
+        "Month: ", as.character(month_label), "<br>",
+        "Mean NDVI: ", sprintf("%.3f", mean_val)
+      )
+    )
+    p <- p %>% plotly::add_lines(
+      data          = sub,
+      x             = ~month_label,
+      y             = ~mean_val,
+      name          = lab,
+      legendgroup   = lc,
+      line          = list(width = 3, color = col),
+      marker        = list(size = 7, color = col),
+      text          = ~hover_line,
+      hovertemplate = "%{text}<extra></extra>"
+    )
+  }
+
+  p %>% plotly::layout(
+    xaxis = xaxis,
+    yaxis = ndvi_y_axis,
+    template = "plotly_white",
+    hovermode = "x unified",
+    legend = list(
+      orientation      = "h",
+      x                = 0.5,
+      xanchor          = "center",
+      y                = 1.02,
+      yanchor          = "bottom",
+      traceorder       = "normal",
+      # ~3 entries per row → 3 wrapped rows for 8 traces (avoids long ribbon vs. class overlap)
+      entrywidth       = 0.32,
+      entrywidthmode   = "fraction",
+      itemsizing       = "constant",
+      tracegroupgap    = 8,
+      bgcolor          = "rgba(255,255,255,0.92)",
+      bordercolor      = "rgba(0,0,0,0.08)",
+      borderwidth      = 1
+    ),
+    margin = list(t = 130, r = 30, l = 60, b = 60)
+  )
+}
+
+#' Shiny UI: title row above Land Cover Plotly chart.
+#' @noRd
+ndvi_landcover_titles_ui <- function(resolution = NULL) {
+  res_suffix <- ndvi_resolution_title_suffix(resolution)
+  shiny::tags$div(
+    class = "ndvi-anomaly-title-wrap",
+    shiny::tags$h4(
+      class = "ndvi-anomaly-title-h4",
+      paste0("NDVI by land cover", res_suffix)
+    )
+  )
+}
+
 # --- NDVI anomaly (Plotly): monthly NDVI vs climatology + historic min/max band ----
 
 aggregate_monthly_ndvi <- function(df) {
@@ -871,11 +1073,22 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     stop("No GeoJSON files found in the specified folder.")
   }
   
-  # Extract filenames 
+  # Extract filenames; stable order for legend / layer control
   landuse_types <- tools::file_path_sans_ext(basename(geojson_files))
+  ord <- order(landuse_types)
+  geojson_files <- geojson_files[ord]
+  landuse_types <- landuse_types[ord]
   
-  # Define a set of colors for the different GeoJSON files
-  colors <- colorFactor(c("#EDE9E4", "#ED022A", "#FFDB5C", "#87D19E", "#A7D282", "#358221", "#1A5BAB"), domain = landuse_types) # LULC colors
+  pal_named <- land_cover_class_colors()
+  hex_by_stem <- vapply(landuse_types, function(stem) {
+    k <- geojson_stem_to_class_key(stem)
+    if (is.na(k) || !k %in% names(pal_named)) {
+      return("#999999")
+    }
+    unname(pal_named[[k]])
+  }, character(1))
+  colors <- leaflet::colorFactor(palette = hex_by_stem, domain = landuse_types)
+  
   # Create a leaflet map with the specified basemap
   map <- leaflet() %>%
     addProviderTiles(providers[[basemap]])

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -554,21 +554,34 @@ ndvi_landcover_titles_ui <- function(resolution = NULL, year = NULL) {
   } else {
     ""
   }
-  shiny::tags$div(
-    class = "ndvi-anomaly-title-wrap",
-    shiny::tags$h4(
-      class = "ndvi-anomaly-title-h4 ndvi-landcover-title-h4",
-      paste0("NDVI by land cover", res_suffix, yr_part),
-      shiny::tags$span(
-        class = "lc-landcover-tooltip-wrap",
-        tabindex = "0",
-        shiny::tags$span(class = "ndvi-help-icon", `aria-label` = "Land cover seasonal patterns", "ⓘ"),
-        shiny::tags$div(
-          class = "lc-landcover-tooltip-panel",
-          role = "tooltip",
-          lc_land_cover_explorer_tooltip_table_tags()
+  shiny::tagList(
+    shiny::tags$div(
+      class = "ndvi-anomaly-title-wrap",
+      shiny::tags$h4(
+        class = "ndvi-anomaly-title-h4 ndvi-landcover-title-h4",
+        paste0("NDVI by land cover", res_suffix, yr_part),
+        shiny::tags$span(
+          class = "lc-landcover-tooltip-wrap",
+          tabindex = "0",
+          shiny::tags$span(class = "ndvi-help-icon", `aria-label` = "Land cover seasonal patterns", "ⓘ"),
+          shiny::tags$div(
+            class = "lc-landcover-tooltip-panel",
+            role = "tooltip",
+            lc_land_cover_explorer_tooltip_table_tags()
+          )
         )
       )
+    ),
+    lc_landcover_tooltip_flip_script()
+  )
+}
+
+#' One-time JS: flip land-cover tooltip panel to the left when it would overflow the viewport.
+#' @noRd
+lc_landcover_tooltip_flip_script <- function() {
+  shiny::tags$script(
+    shiny::HTML(
+      "(function(){if(window.__lcLandcoverTooltipFlip)return;window.__lcLandcoverTooltipFlip=true;\nfunction setFlip(wrap){\nvar panel=wrap.querySelector('.lc-landcover-tooltip-panel');\nif(!panel)return;\nrequestAnimationFrame(function(){\nrequestAnimationFrame(function(){\nvar pw=panel.getBoundingClientRect().width;\nif(!pw||pw<10)pw=Math.min(560,window.innerWidth-48);\nvar rect=wrap.getBoundingClientRect();\nvar margin=10;\nvar pad=4;\nvar overflowRight=rect.right+margin+pw>window.innerWidth-pad;\nvar spaceLeft=rect.left-margin;\nif(overflowRight&&spaceLeft>=pw){\nwrap.classList.add('lc-flip-left');\n}else{\nwrap.classList.remove('lc-flip-left');\n}\n});});\n}\nif(typeof jQuery!=='undefined'){\njQuery(document).on('mouseenter.lcflip focusin.lcflip','.lc-landcover-tooltip-wrap',function(){setFlip(this);});\njQuery(document).on('mouseleave.lcflip','.lc-landcover-tooltip-wrap',function(){jQuery(this).removeClass('lc-flip-left');});\njQuery(document).on('focusout.lcflip','.lc-landcover-tooltip-wrap',function(){\nvar w=this;setTimeout(function(){if(!w.contains(document.activeElement))jQuery(w).removeClass('lc-flip-left');},0);\n});\njQuery(window).on('resize.lcflip',function(){jQuery('.lc-landcover-tooltip-wrap').each(function(){var w=this;if(jQuery(w).is(':hover')||jQuery(w).find(':focus').length)setFlip(w);});});\n}\n})();"
     )
   )
 }

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -372,6 +372,58 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
     showgrid   = FALSE
   )
 
+  # Y limits from train + test so the scale stays stable when only the test year changes
+  pad_y_range <- function(lo, hi, pad = 0.05) {
+    if (!is.finite(lo) || !is.finite(hi)) return(NULL)
+    if (lo > hi) return(NULL)
+    if (abs(hi - lo) < 1e-9) {
+      pad_abs <- max(0.02, abs(lo) * 0.05 + 0.01)
+      return(c(lo - pad_abs, hi + pad_abs))
+    }
+    span <- hi - lo
+    c(lo - pad * span, hi + pad * span)
+  }
+  vals_ndvi_y <- c(
+    train_monthly$NDVI,
+    test_monthly$NDVI,
+    historic_range$lower,
+    historic_range$upper,
+    climatology_df$climatology
+  )
+  vals_ndvi_y <- vals_ndvi_y[is.finite(vals_ndvi_y)]
+  rng_ndvi <- if (length(vals_ndvi_y)) {
+    pad_y_range(min(vals_ndvi_y), max(vals_ndvi_y))
+  } else {
+    NULL
+  }
+
+  train_anom_df <- make_anomaly_data(train_monthly, climatology_df)
+  test_anom_df <- make_anomaly_data(test_monthly, climatology_df)
+  vals_anom_y <- c(train_anom_df$anomaly, test_anom_df$anomaly)
+  vals_anom_y <- vals_anom_y[is.finite(vals_anom_y)]
+  rng_anom <- if (length(vals_anom_y)) {
+    pad_y_range(min(vals_anom_y), max(vals_anom_y))
+  } else {
+    NULL
+  }
+
+  ndvi_y_axis <- list(
+    title = "NDVI", showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)"
+  )
+  if (!is.null(rng_ndvi)) {
+    ndvi_y_axis$range <- rng_ndvi
+    ndvi_y_axis$autorange <- FALSE
+  }
+
+  ndvi_anomaly_y_axis <- list(
+    title = "NDVI Anomaly", zeroline = TRUE, zerolinewidth = 2, zerolinecolor = "gray50",
+    showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)"
+  )
+  if (!is.null(rng_anom)) {
+    ndvi_anomaly_y_axis$range <- rng_anom
+    ndvi_anomaly_y_axis$autorange <- FALSE
+  }
+
   p1 <- plotly::plot_ly() %>%
     plotly::add_ribbons(
       data      = plot_df,
@@ -402,7 +454,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
     ) %>%
     plotly::layout(
       xaxis = common_xaxis,
-      yaxis = list(title = "NDVI", showgrid = TRUE, gridcolor = "rgba(0,0,0,0.08)"),
+      yaxis = ndvi_y_axis,
       template = "plotly_white",
       hovermode  = "x unified",
       legend = list(
@@ -428,14 +480,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
   ) %>%
     plotly::layout(
       xaxis = common_xaxis,
-      yaxis = list(
-        title           = "NDVI Anomaly",
-        zeroline        = TRUE,
-        zerolinewidth   = 2,
-        zerolinecolor   = "gray50",
-        showgrid        = TRUE,
-        gridcolor       = "rgba(0,0,0,0.08)"
-      ),
+      yaxis = ndvi_anomaly_y_axis,
       template = "plotly_white",
       margin   = list(t = 30, r = 30, l = 60, b = 80)
     )

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -387,7 +387,7 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   list(p = p, bbox_by_stem = bbox_by_stem)
 }
 
-#' NDVI chart stacked above Plotly geo map; shared \code{legendgroup} links legend to lines + polygons.
+#' NDVI chart beside Plotly mapbox map (two columns); shared \code{legendgroup} links legend to lines + polygons.
 #' @param aoi_sf Optional study-area polygon(s); passed to the map layer as a persistent outline.
 #' @noRd
 plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
@@ -408,9 +408,9 @@ plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
   out <- plotly::subplot(
     p_ts,
     mp$p,
-    nrows = 2,
-    heights = c(0.48, 0.52),
-    margin = 0.05,
+    nrows = 1,
+    widths = c(0.5, 0.5),
+    margin = 0.06,
     titleY = TRUE
   )
   out <- out %>%

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -322,11 +322,32 @@ ndvi_insight_smk_card_ui <- function(stats) {
   )
 }
 
+ndvi_monthly_year_span_label <- function(monthly_df) {
+  if (is.null(monthly_df) || nrow(monthly_df) == 0L) return("")
+  ym <- monthly_df$YearMonth
+  ym <- ym[!is.na(ym)]
+  if (length(ym) == 0L) return("")
+  y_lo <- lubridate::year(min(ym))
+  y_hi <- lubridate::year(max(ym))
+  if (is.na(y_lo) || is.na(y_hi)) return("")
+  if (y_lo == y_hi) as.character(y_lo) else paste0(y_lo, "\u2013", y_hi)
+}
+
 #' Interactive NDVI time series vs training climatology and historic range (plotly).
 #' Titles with help icon: use ndvi_anomaly_titles_ui() in Shiny above plotlyOutput.
 plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
   train_monthly <- aggregate_monthly_ndvi(train_ndvi_df %>% dplyr::select(YearMonth, NDVI))
   test_monthly  <- aggregate_monthly_ndvi(test_ndvi_df %>% dplyr::select(YearMonth, NDVI))
+
+  train_yr <- ndvi_monthly_year_span_label(train_monthly)
+  test_yr <- ndvi_monthly_year_span_label(test_monthly)
+  name_ribbon <- if (nzchar(train_yr)) paste0("NDVI historic range (", train_yr, ")") else "NDVI historic range"
+  name_current <- if (nzchar(test_yr)) paste0("Current NDVI (", test_yr, ")") else "Current NDVI"
+  name_clim <- if (nzchar(train_yr)) {
+    paste0("Historical monthly average (", train_yr, ")")
+  } else {
+    "Historical monthly average"
+  }
 
   climatology_df <- get_monthly_climatology(train_monthly)
   historic_range   <- get_monthly_historic_range(train_monthly)
@@ -357,7 +378,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
       x         = ~YearMonth,
       ymin      = ~lower,
       ymax      = ~upper,
-      name      = "NDVI historic range",
+      name      = name_ribbon,
       legendgroup = "historic",
       fillcolor = "rgba(39, 129, 207, 0.2)",
       line      = list(color = "transparent"),
@@ -367,7 +388,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
       data            = plot_df,
       x               = ~YearMonth, y = ~NDVI,
       type            = "scatter", mode = "lines+markers",
-      name            = "Current NDVI",
+      name            = name_current,
       line            = list(width = 3, color = "#0072B2"),
       marker          = list(size = 7, color = "#0072B2"),
       hovertemplate   = "Date: %{x|%b %Y}<br>NDVI: %{y:.3f}<extra></extra>"
@@ -375,7 +396,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
     plotly::add_lines(
       data            = plot_df,
       x               = ~YearMonth, y = ~climatology,
-      name            = "Historical monthly average",
+      name            = name_clim,
       line            = list(width = 2.5, dash = "dash", color = "#E69F00"),
       hovertemplate   = "Date: %{x|%b %Y}<br>Historical average: %{y:.3f}<extra></extra>"
     ) %>%

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -357,7 +357,7 @@ plot_ndvi_anomaly <- function(train_ndvi_df = NULL, test_ndvi_df = NULL) {
       x         = ~YearMonth,
       ymin      = ~lower,
       ymax      = ~upper,
-      name      = "NDVI historic range (train)",
+      name      = "NDVI historic range",
       legendgroup = "historic",
       fillcolor = "rgba(39, 129, 207, 0.2)",
       line      = list(color = "transparent"),

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -149,19 +149,14 @@ ndvi_anomaly_help_tooltip_text <- function() {
 ndvi_anomaly_titles_ui <- function(resolution = NULL) {
   res_suffix <- ndvi_resolution_title_suffix(resolution)
   tip <- ndvi_anomaly_help_tooltip_text()
-  icon_style <- paste(
-    "color: #0073e6;",
-    "margin-left: 0.35em;",
-    "cursor: help;"
-  )
   shiny::tags$div(
-    style = "display: block; width: 100%; box-sizing: border-box;",
+    class = "ndvi-anomaly-title-wrap",
     shiny::tags$h4(
-      style = "text-align: center; margin: 0 0 0.75em 0;",
+      class = "ndvi-anomaly-title-h4",
       paste0("NDVI Anomaly", res_suffix),
       shiny::tags$span(
         title = tip,
-        style = icon_style,
+        class = "ndvi-help-icon",
         "ⓘ"
       )
     )
@@ -229,12 +224,14 @@ compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
   )
 }
 
-ndvi_insight_card_base_style <- function() {
-  "background: #f8f9fa; border: 1px solid #e0e0e0; border-radius: 10px; padding: 15px; height: 100%; box-sizing: border-box;"
-}
-
-ndvi_insight_icon_style <- function() {
-  "color: #0073e6; margin-left: 0.35em; cursor: help;"
+ndvi_insight_main_class <- function(col) {
+  if (identical(col, "#009E73")) {
+    "ndvi-insight-card__main ndvi-insight-card__main--positive"
+  } else if (identical(col, "#D55E00")) {
+    "ndvi-insight-card__main ndvi-insight-card__main--negative"
+  } else {
+    "ndvi-insight-card__main ndvi-insight-card__main--neutral"
+  }
 }
 
 #' Shiny UI: Current Year Condition card (uses compute_ndvi_explorer_stats output).
@@ -242,7 +239,6 @@ ndvi_insight_wilcox_card_ui <- function(stats) {
   if (is.null(stats)) return(NULL)
   p <- stats$wilcox_p
   med <- stats$wilcox_median
-  icon_st <- ndvi_insight_icon_style()
   if (is.na(p)) {
     main <- "Not enough data for this summary"
     col <- "#555555"
@@ -261,22 +257,22 @@ ndvi_insight_wilcox_card_ui <- function(stats) {
     p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
   }
   shiny::tags$div(
-    style = ndvi_insight_card_base_style(),
+    class = "ndvi-insight-card",
     shiny::tags$h4(
-      style = "font-size: 16px; margin: 0 0 12px 0; font-weight: 600;",
+      class = "ndvi-insight-card__heading",
       "Current Year Condition",
       shiny::tags$span(
         title = ndvi_insight_wilcox_tooltip(),
-        style = icon_st,
+        class = "ndvi-help-icon",
         "ⓘ"
       )
     ),
     shiny::tags$div(
-      style = paste0("font-size: 20px; font-weight: bold; color: ", col, "; line-height: 1.3;"),
+      class = ndvi_insight_main_class(col),
       main
     ),
     shiny::tags$div(
-      style = "font-size: 13px; color: #666; margin-top: 10px;",
+      class = "ndvi-insight-card__footer",
       p_lab
     )
   )
@@ -287,7 +283,6 @@ ndvi_insight_smk_card_ui <- function(stats) {
   if (is.null(stats)) return(NULL)
   p <- stats$smk_p
   slope <- stats$sen_slope
-  icon_st <- ndvi_insight_icon_style()
   if (is.na(p) || is.na(slope)) {
     main <- "Long-term trend cannot be assessed from this series"
     col <- "#555555"
@@ -306,22 +301,22 @@ ndvi_insight_smk_card_ui <- function(stats) {
     p_lab <- paste0("p-value: ", format(round(p, 3), nsmall = 3))
   }
   shiny::tags$div(
-    style = ndvi_insight_card_base_style(),
+    class = "ndvi-insight-card",
     shiny::tags$h4(
-      style = "font-size: 16px; margin: 0 0 12px 0; font-weight: 600;",
+      class = "ndvi-insight-card__heading",
       "Long-Term Trend",
       shiny::tags$span(
         title = ndvi_insight_smk_tooltip(),
-        style = icon_st,
+        class = "ndvi-help-icon",
         "ⓘ"
       )
     ),
     shiny::tags$div(
-      style = paste0("font-size: 20px; font-weight: bold; color: ", col, "; line-height: 1.3;"),
+      class = ndvi_insight_main_class(col),
       main
     ),
     shiny::tags$div(
-      style = "font-size: 13px; color: #666; margin-top: 10px;",
+      class = "ndvi-insight-card__footer",
       p_lab
     )
   )

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -133,10 +133,12 @@ land_cover_class_legend_labels <- function() {
 }
 
 #' Multi-line Plotly NDVI by land cover + AoI historic CI ribbon (NDVI TS–style layout).
+#' @param for_subplot If TRUE, tighter margins for stacking under a map panel.
 #' @noRd
 plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
                                           land_cover_summaries = NULL,
-                                          name_ribbon = "Historical range") {
+                                          name_ribbon = "Historical range",
+                                          for_subplot = FALSE) {
   # Extra padding + absolute margin so ribbon CIs and sharp dips stay inside the frame.
   pad_y_range <- function(lo, hi, pad = 0.14, abs_margin = 0.035) {
     if (!is.finite(lo) || !is.finite(hi)) {
@@ -247,6 +249,9 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
     )
   }
 
+  leg_y <- if (isTRUE(for_subplot)) 1.05 else 1.08
+  margin_t <- if (isTRUE(for_subplot)) 80 else 118
+  margin_b <- if (isTRUE(for_subplot)) 50 else 60
   p %>% plotly::layout(
     xaxis = xaxis,
     yaxis = ndvi_y_axis,
@@ -256,7 +261,7 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
       orientation      = "h",
       x                = 0.5,
       xanchor          = "center",
-      y                = 1.08,
+      y                = leg_y,
       yanchor          = "bottom",
       traceorder       = "normal",
       # ~3 entries per row → 3 wrapped rows for 8 traces (avoids long ribbon vs. class overlap)
@@ -268,8 +273,150 @@ plot_ndvi_landcover_multiline <- function(train_ndvi_summary_aoi = NULL,
       bordercolor      = "rgba(0,0,0,0.08)",
       borderwidth      = 1
     ),
-    margin = list(t = 118, r = 30, l = 60, b = 60)
+    margin = list(t = margin_t, r = 30, l = 60, b = margin_b)
   )
+}
+
+#' Plotly geo map of LULC polygons from the same GeoJSON folder as Leaflet; \code{legendgroup} matches NDVI lines.
+#' @param aoi_sf Optional study-area polygon(s) in any CRS; drawn as a non-legend outline under LULC so the map
+#'   is not empty when all classes are toggled off.
+#' @return List with \code{p} (plotly), \code{bbox_by_stem} (named list of bboxes).
+#' @noRd
+plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
+  message(paste("Plotting LULC GeoJSON for Plotly map:", folder_path))
+  geojson_files <- list.files(folder_path, pattern = "\\.geojson$", full.names = TRUE)
+  if (length(geojson_files) == 0) {
+    stop("No GeoJSON files found in the specified folder.")
+  }
+  landuse_types <- tools::file_path_sans_ext(basename(geojson_files))
+  ord <- order(landuse_types)
+  geojson_files <- geojson_files[ord]
+  landuse_types <- landuse_types[ord]
+  pal_named <- land_cover_class_colors()
+  bbox_by_stem <- vector("list", length(landuse_types))
+  names(bbox_by_stem) <- landuse_types
+  p <- plotly::plot_ly()
+  all_xmin <- all_xmax <- all_ymin <- all_ymax <- numeric(0)
+  aoi_ok <- !is.null(aoi_sf) && inherits(aoi_sf, "sf") && nrow(aoi_sf) > 0L &&
+    !all(sf::st_is_empty(sf::st_geometry(aoi_sf)))
+  if (isTRUE(aoi_ok)) {
+    aoi_wgs <- sf::st_transform(aoi_sf, 4326)
+    bb_aoi <- sf::st_bbox(aoi_wgs)
+    all_xmin <- c(all_xmin, bb_aoi[["xmin"]])
+    all_xmax <- c(all_xmax, bb_aoi[["xmax"]])
+    all_ymin <- c(all_ymin, bb_aoi[["ymin"]])
+    all_ymax <- c(all_ymax, bb_aoi[["ymax"]])
+    p <- p %>% plotly::add_sf(
+      data = aoi_wgs,
+      inherit = FALSE,
+      name = "Study area",
+      showlegend = FALSE,
+      fillcolor = "rgba(0,0,0,0)",
+      line = list(color = "#222222", width = 2),
+      hoverinfo = "text",
+      text = "Study area"
+    )
+  }
+  for (i in seq_along(geojson_files)) {
+    stem <- landuse_types[i]
+    geojson_data <- sf::st_read(geojson_files[i], quiet = TRUE)
+    geojson_data <- sf::st_transform(geojson_data, crs = 4326)
+    bbox_by_stem[[stem]] <- sf::st_bbox(geojson_data)
+    lab_short <- geojson_stem_to_class_key(stem)
+    pop_lab <- if (!is.na(lab_short) && lab_short %in% names(land_cover_class_legend_labels())) {
+      unname(land_cover_class_legend_labels()[[lab_short]])
+    } else {
+      stem
+    }
+    col <- if (!is.na(lab_short) && lab_short %in% names(pal_named)) {
+      unname(pal_named[[lab_short]])
+    } else {
+      "#999999"
+    }
+    area_ha <- sum(as.numeric(sf::st_area(geojson_data))) / 10000
+    htxt <- paste0(
+      "<b>", htmltools::htmlEscape(pop_lab), "</b><br>",
+      "Area (hectares): ", round(area_ha, 3)
+    )
+    bb <- bbox_by_stem[[stem]]
+    all_xmin <- c(all_xmin, bb[["xmin"]])
+    all_xmax <- c(all_xmax, bb[["xmax"]])
+    all_ymin <- c(all_ymin, bb[["ymin"]])
+    all_ymax <- c(all_ymax, bb[["ymax"]])
+    lg <- if (!is.na(lab_short)) lab_short else stem
+    p <- p %>% plotly::add_sf(
+      data = geojson_data,
+      inherit = FALSE,
+      name = pop_lab,
+      legendgroup = lg,
+      showlegend = FALSE,
+      fillcolor = paste0(col, "99"),
+      line = list(color = col, width = 2),
+      hoverinfo = "text",
+      text = htxt
+    )
+  }
+  pad <- 0.03
+  lon_range <- range(c(all_xmin, all_xmax))
+  lat_range <- range(c(all_ymin, all_ymax))
+  dx <- diff(lon_range)
+  dy <- diff(lat_range)
+  if (!is.finite(dx) || dx < 1e-6) {
+    dx <- 0.05
+  }
+  if (!is.finite(dy) || dy < 1e-6) {
+    dy <- 0.05
+  }
+  lon_range <- lon_range + c(-1, 1) * dx * pad
+  lat_range <- lat_range + c(-1, 1) * dy * pad
+  p <- p %>% plotly::layout(
+    geo = list(
+      scope = "world",
+      projection = list(type = "mercator"),
+      lonaxis = list(range = lon_range),
+      lataxis = list(range = lat_range),
+      showland = TRUE,
+      landcolor = "rgb(245,245,245)",
+      showocean = TRUE,
+      oceancolor = "rgb(220,235,245)",
+      bgcolor = "rgba(255,255,255,0)"
+    ),
+    margin = list(l = 8, r = 8, t = 28, b = 8),
+    title = list(text = "Land cover", font = list(size = 12), y = 0.98, yref = "paper")
+  )
+  list(p = p, bbox_by_stem = bbox_by_stem)
+}
+
+#' NDVI chart stacked above Plotly geo map; shared \code{legendgroup} links legend to lines + polygons.
+#' @param aoi_sf Optional study-area polygon(s); passed to the map layer as a persistent outline.
+#' @noRd
+plot_ndvi_landcover_with_map <- function(train_ndvi_summary_aoi = NULL,
+                                         land_cover_summaries = NULL,
+                                         name_ribbon = "Historical range",
+                                         lulc_map_folder = NULL,
+                                         aoi_sf = NULL) {
+  if (is.null(lulc_map_folder) || !nzchar(lulc_map_folder) || !dir.exists(lulc_map_folder)) {
+    stop("lulc_map_folder must be an existing directory with GeoJSON files.")
+  }
+  p_ts <- plot_ndvi_landcover_multiline(
+    train_ndvi_summary_aoi = train_ndvi_summary_aoi,
+    land_cover_summaries   = land_cover_summaries,
+    name_ribbon            = name_ribbon,
+    for_subplot            = TRUE
+  )
+  mp <- plot_lulc_map_plotly_from_folder(lulc_map_folder, aoi_sf = aoi_sf)
+  out <- plotly::subplot(
+    p_ts,
+    mp$p,
+    nrows = 2,
+    heights = c(0.48, 0.52),
+    margin = 0.05,
+    titleY = TRUE
+  )
+  out <- out %>%
+    plotly::layout(dragmode = "zoom") %>%
+    plotly::config(scrollZoom = TRUE, displayModeBar = TRUE)
+  list(plot = out, bbox_by_stem = mp$bbox_by_stem)
 }
 
 #' Shiny UI: title row above Land Cover Plotly chart.
@@ -1079,7 +1226,7 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     stop("No GeoJSON files found in the specified folder.")
   }
   
-  # Extract filenames; stable order for legend / layer control
+  # Extract filenames; stable order for overlay group names
   landuse_types <- tools::file_path_sans_ext(basename(geojson_files))
   ord <- order(landuse_types)
   geojson_files <- geojson_files[ord]
@@ -1099,6 +1246,9 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
   map <- leaflet() %>%
     addProviderTiles(providers[[basemap]])
   
+  bbox_by_stem <- vector("list", length(landuse_types))
+  names(bbox_by_stem) <- landuse_types
+  
   # Loop through each GeoJSON file and add it to the map
   for (i in seq_along(geojson_files)) {
     file <- geojson_files[i]
@@ -1109,6 +1259,7 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     
     # Transform the GeoJSON data to WGS 84 (EPSG:4326)
     geojson_data <- sf::st_transform(geojson_data, crs = 4326)
+    bbox_by_stem[[landuse_type]] <- sf::st_bbox(geojson_data)
     
     # layerId + group: Shiny Leaflet shape_click identifies the land-cover layer
     lab_short <- geojson_stem_to_class_key(landuse_type)
@@ -1133,22 +1284,6 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
       )
   }
   
-  # Add the layers control to the map
-  map <- map %>%
-    addLayersControl(
-      overlayGroups = landuse_types,
-      options = layersControlOptions(collapsed = FALSE)
-    )
-  
-  # Add legend to the map
-  map <- map %>%
-    addLegend("bottomright", 
-              pal = colors, 
-              values = landuse_types, 
-              title = "Land Use Type",
-              labFormat = labelFormat(transform = function(x) x),
-              opacity = 1)
-  
   # Save the plot if save_path is provided
   if (!is.null(save_path)) {
     # Ensure the save directory exists
@@ -1160,11 +1295,59 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     saveWidget(map, file.path(save_path, filename), selfcontained = TRUE)
   }
   
-  # Return the map
-  return(map)
+  # Return map plus per-layer bboxes for leafletProxy fitBounds (Plotly -> map)
+  return(list(map = map, bbox_by_stem = bbox_by_stem))
 }
 
-#' Sync Land Cover Leaflet clicks with Plotly line emphasis (lc_ndvi_plot_output).
+#' Map human legend label to GeoJSON stem using class keys (see bbox_by_stem names).
+#' @noRd
+landcover_label_to_stem <- function(label, bbox_by_stem) {
+  if (is.null(label) || !nzchar(label)) {
+    return(NA_character_)
+  }
+  if (is.null(bbox_by_stem) || !length(bbox_by_stem)) {
+    return(NA_character_)
+  }
+  labs <- land_cover_class_legend_labels()
+  for (k in names(labs)) {
+    if (identical(unname(labs[[k]]), label)) {
+      for (st in names(bbox_by_stem)) {
+        if (identical(geojson_stem_to_class_key(st), k)) {
+          return(st)
+        }
+      }
+      return(NA_character_)
+    }
+  }
+  NA_character_
+}
+
+#' Pan combined NDVI+map Plotly figure to a WGS84 bbox (uses layout \code{geo*} from \code{plotly_build}).
+#' @noRd
+lc_plotly_relayout_geo_bbox <- function(session, plotly_output_id, plot_obj, bbox) {
+  if (is.null(bbox)) {
+    return(invisible(NULL))
+  }
+  xmin <- bbox[["xmin"]]
+  xmax <- bbox[["xmax"]]
+  ymin <- bbox[["ymin"]]
+  ymax <- bbox[["ymax"]]
+  if (any(!is.finite(c(xmin, xmax, ymin, ymax)))) {
+    return(invisible(NULL))
+  }
+  pb <- plotly::plotly_build(plot_obj)
+  lay <- pb$x$layout
+  geo_keys <- grep("^geo[0-9]*$", names(lay), value = TRUE)
+  gk <- if (length(geo_keys)) geo_keys[length(geo_keys)] else "geo"
+  rl <- list()
+  rl[[paste0(gk, ".lonaxis.range")]] <- c(xmin, xmax)
+  rl[[paste0(gk, ".lataxis.range")]] <- c(ymin, ymax)
+  prx <- plotly::plotlyProxy(plotly_output_id, session)
+  plotly::plotlyProxyInvoke(prx, "relayout", rl)
+  invisible(NULL)
+}
+
+#' Sync Land Cover plot/map clicks with Plotly line emphasis (lc_ndvi_plot_output).
 #' @noRd
 lc_landcover_emphasize_plotly_traces <- function(session, plotly_output_id, plot_obj, highlight_label = NULL) {
   if (is.null(plot_obj)) {

--- a/app/ui.R
+++ b/app/ui.R
@@ -7,7 +7,7 @@ ui <- fluidPage(
   shiny.i18n::usei18n(i18n),
   extendShinyjs(text=js_lang, functions=c()),
   includeCSS("www/style.css"),
-  
+
   mod_header_ui("header"),
   
   div(class = "mainContainer",

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -47,7 +47,14 @@ mod_body_ui <- function(id) {
                       value = "NDVItsTab",
                       conditionalPanel(condition = "input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab'", # Show this figure only when on this tab/subtab combination
                                        div(style = "margin-left: 10px; margin-top: 10px; margin-right: 10px;",
-                                           uiOutput("ndvi_ts_plot_container"))),
+                                           uiOutput("ndvi_ts_plot_container"),
+                                           div(
+                                             style = "margin-top: 12px;",
+                                             fluidRow(
+                                               column(6, uiOutput("wilcoxon_card")),
+                                               column(6, uiOutput("smk_card"))
+                                             )
+                                           ))),
                       # Busy Spinner always available for this tab
                       div(style = "position: fixed; top: 45%; left: 60%; transform: translate(-50%, -50%);", 
                           add_busy_spinner(spin = "fading-circle", width = "100px", height = "100px"))

--- a/app/ui/mod_sidebar_ui.R
+++ b/app/ui/mod_sidebar_ui.R
@@ -70,11 +70,7 @@ mod_sidebar_ui <- function(id) {
     
     # NDVI Land Cover Explorer page-specific selector and button (specific to be able to link output generation to button press)
     conditionalPanel(condition = "input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'LCexplorerTab'",
-                     div(selectInput("landcover_Type", "Select land cover type",
-                                     selected = "Crops",
-                                     choices = c("Crops", "Rangeland", "Water", "Trees", "Flooded Vegetation" = "Flooded_vegetation", 
-                                                 "Built Area" = "Built_Area", "Bare Ground" = "Bare_ground")), 
-                         actionButton("generate_lc_figures", "Generate Figures", class = "action_button"))
+                     div(actionButton("generate_lc_figures", "Generate Figures", class = "action_button"))
                      ),
     
     # NDVI Delta Map page-specific button (specific to be able to link output generation to button press)

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -6,12 +6,17 @@
   margin: 0;
   padding: 0;
 }
-body, html {
-  height: 100%;
+html {
+  min-height: 100%;
+  height: auto;
+}
+body {
+  min-height: 100%;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #333;
   background: #fff;
-  overflow-x: visible;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* ============================
@@ -243,7 +248,22 @@ textarea::-ms-input-placeholder {
   flex-direction: column;
   background: #fff;
   border-top-right-radius: 8px;
-  overflow: hidden;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Let tab panels grow with tall Plotly/HTML; scroll happens on .content */
+.content .tabbable {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.content .tab-content {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* 1) eerste: alle tab-panes weer verbergen zoals bootstrap beoogt */
@@ -452,11 +472,11 @@ input {
 /*################################### */
 /* Added CSS for Environmental TS App */
 
-/* Generic image container */
+/* Generic image container (tall Plotly stacks scroll via .content; do not clip) */
 .image-fill {
-  height: 100%;       /* container must have a parent height */
+  min-height: 0;
   display: flex;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* Top-center alignment */
@@ -465,12 +485,12 @@ input {
   align-items: flex-start;  /* stick to top */
 }
 
-/* Images inside these containers */
+/* Images: natural height when parent scrolls (avoid 100% of undefined) */
 .image-fill img {
   max-width: 100%;
-  max-height: 100%;
-  height: 100%;
+  height: auto;
   width: auto;
+  max-height: none;
   object-fit: contain;
   flex-shrink: 0;
 }

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -551,6 +551,13 @@ input {
 .lc-landcover-tooltip-wrap:focus-within .lc-landcover-tooltip-panel {
   display: block;
 }
+/* JS adds .lc-flip-left when panel would overflow the right edge of the viewport */
+.lc-landcover-tooltip-wrap.lc-flip-left .lc-landcover-tooltip-panel {
+  left: auto;
+  right: 100%;
+  margin-left: 0;
+  margin-right: 10px;
+}
 table.lc-landcover-tooltip-table {
   border-collapse: collapse;
   width: 100%;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -518,6 +518,68 @@ input {
   cursor: help;
 }
 
+/* Land Cover Explorer: HTML table on hover (avoids third-party tooltip HTML issues in Chrome) */
+.lc-landcover-tooltip-wrap {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.35em;
+  vertical-align: baseline;
+  outline: none;
+}
+.lc-landcover-tooltip-wrap .ndvi-help-icon {
+  margin-left: 0;
+}
+.lc-landcover-tooltip-panel {
+  display: none;
+  position: absolute;
+  left: 100%;
+  /* Align top with icon: vertical centering pushed tall panels off the top of the viewport */
+  top: 0;
+  transform: none;
+  margin-left: 10px;
+  z-index: 10050;
+  box-sizing: border-box;
+  width: min(560px, calc(100vw - 48px));
+  max-height: min(85vh, 640px);
+  overflow: auto;
+  background: #fff;
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  padding: 0;
+}
+.lc-landcover-tooltip-wrap:hover .lc-landcover-tooltip-panel,
+.lc-landcover-tooltip-wrap:focus-within .lc-landcover-tooltip-panel {
+  display: block;
+}
+table.lc-landcover-tooltip-table {
+  border-collapse: collapse;
+  width: 100%;
+  min-width: 100%;
+  table-layout: fixed;
+  font-size: 12px;
+  border: 1px solid #ccc;
+}
+table.lc-landcover-tooltip-table th,
+table.lc-landcover-tooltip-table td {
+  border: 1px solid #ccc;
+  padding: 6px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+table.lc-landcover-tooltip-table th:first-child,
+table.lc-landcover-tooltip-table td:first-child {
+  width: 15%;
+}
+table.lc-landcover-tooltip-table th:nth-child(2),
+table.lc-landcover-tooltip-table td:nth-child(2) {
+  width: 85%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+table.lc-landcover-tooltip-table thead tr {
+  background: #e9e9e9;
+}
+
 .ndvi-insight-card {
   background: #f8f9fa;
   border: 1px solid #e0e0e0;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -487,6 +487,11 @@ input {
   text-align: center;
   margin: 0 0 0.75em 0;
 }
+/* Land Cover chart: title sits just above in-plot legend — keep gap small */
+.ndvi-landcover-title-h4 {
+  text-align: center;
+  margin: 0 0 0.2rem 0;
+}
 .ndvi-help-icon {
   color: #0073e6;
   margin-left: 0.35em;

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -474,3 +474,67 @@ input {
   object-fit: contain;
   flex-shrink: 0;
 }
+
+/* ============================
+   NDVI Explorer: anomaly title, insight cards, plot stack
+   ============================ */
+.ndvi-anomaly-title-wrap {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+}
+.ndvi-anomaly-title-h4 {
+  text-align: center;
+  margin: 0 0 0.75em 0;
+}
+.ndvi-help-icon {
+  color: #0073e6;
+  margin-left: 0.35em;
+  cursor: help;
+}
+
+.ndvi-insight-card {
+  background: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 15px;
+  height: 100%;
+  box-sizing: border-box;
+}
+.ndvi-insight-card__heading {
+  font-size: 16px;
+  margin: 0 0 12px 0;
+  font-weight: 600;
+}
+.ndvi-insight-card__main {
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 1.3;
+}
+.ndvi-insight-card__main--positive {
+  color: #009e73;
+}
+.ndvi-insight-card__main--negative {
+  color: #d55e00;
+}
+.ndvi-insight-card__main--neutral {
+  color: #555555;
+}
+.ndvi-insight-card__footer {
+  font-size: 13px;
+  color: #666;
+  margin-top: 10px;
+}
+
+.ndvi-ts-plot-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+/* Beats .image-fill.top-center (align-items: flex-start) for NDVI title + plot column */
+.image-fill.top-center.ndvi-ts-plot-stack {
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary

Enhance the NDVI Land Cover Explorer with an interactive multi-class 
time series plot, two-way plot-map interaction, and contextual 
land cover tooltips.

## Changes

### Multi-class time series plot
- Replaced the single land cover line chart with a **multi-line 
  Plotly chart** showing all land cover types simultaneously
- Each land cover type is represented by a distinct coloured line

### Interactive plot-map linking
- Clicking a **legend item** in the time series plot toggles the 
  corresponding land cover layer on/off in the map
- The plot and map are now **synchronised** — both reflect the 
  same active land cover selection at all times

### Land cover tooltip
- Added a **ⓘ icon** next to the plot title
- Hovering over the icon shows a tooltip table explaining each 
  land cover type and its typical seasonal NDVI pattern

### Scrollable layout
- Added scroll behaviour to the Land Cover Explorer panel

## Screenshots
<img width="1710" height="887" alt="image" src="https://github.com/user-attachments/assets/3b5ea836-fe6b-4ac7-8780-a04b5a10ae30" />

<img width="1697" height="897" alt="image" src="https://github.com/user-attachments/assets/52ca9e34-ac5f-4638-b9eb-45066511ae97" />

<img width="507" height="217" alt="image" src="https://github.com/user-attachments/assets/300a0a0e-6d93-451a-ad78-13c84944fb4c" />