### PR TITLE
Data pipeline integration — three-path loading, GitHub Actions automation, and AI Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,55 @@
 # Environmental Time Series Analysis
 
-A [Shiny](https://shiny.posit.co/) web application by [Sensing Clues](https://www.sensingclues.org) for exploring and visualizing environmental remote sensing time series data, including NDVI (vegetation) and Burned Area analyses across multiple conservation project areas.
+<!-- TODO: replace the "#" in the Data API badge below with the deployed Data API URL once it is live -->
+[![Shiny App – Production](https://img.shields.io/badge/Shiny_App-Production-2E7D32?logo=r&logoColor=white)](https://analytical.sensingclues.org/environmentaltimeseries/)
+[![Shiny App – Test](https://img.shields.io/badge/Shiny_App-Test-F57C00?logo=r&logoColor=white)](https://analytical.sensingclues.org/test/environmentaltimeseries/)
+[![Data API – coming soon](https://img.shields.io/badge/Data_API-coming_soon-9E9E9E?logo=fastapi&logoColor=white)](#)
+
+A [Shiny](https://shiny.posit.co/) web application by [Sensing Clues](https://www.sensingclues.org) for exploring and visualizing environmental remote sensing time series data, including NDVI (vegetation), Burned Area, and land cover analyses across multiple conservation project areas. The app pairs interactive explorers with an AI Assistant that can answer questions and generate charts, tables, and maps on demand.
 
 ## Features
 
 ### NDVI Explorer
 
--   **Time Series** — Plot multi-year NDVI trends for a selected project area and spatial resolution.
--   **Land Cover Explorer** — Visualize NDVI trends broken down by land cover type (crops, rangeland, water, trees, flooded vegetation, built area, bare ground), alongside an interactive land use/land cover map.
--   **Delta Map** — Generate static and interactive maps showing NDVI change (delta) for a selected month and year.
+-   **Time Series** — Two views: a **Monthly view** showing the seasonal NDVI pattern with a historical range band, a vegetation-health summary card, and statistical trend cards (Wilcoxon signed-rank and Seasonal Mann–Kendall); and an **Annual view** showing the year-by-year long-term trend.
+-   **Land Cover Explorer** — NDVI trends broken down by land cover type (crops, rangeland, water, trees, flooded vegetation, built area, bare ground), alongside an interactive land use/land cover map.
+-   **Delta Map** — A **Monthly view** showing NDVI change against the same month in previous years, and an **Annual change view** comparing the average vegetation health between two selected years across the landscape.
 
 ### Burned Area Explorer
 
--   **Time Series** — Plot burned area trends over time for a selected project area.
--   **Map Explorer** — Generate static burned area maps and interactive maps for a specific month and year, with GeoJSON export functionality.
+-   **Time Series** — A **Seasonal Overview** of monthly burned area against a historical range band, and a **Daily Activity** view showing day-level fire detections across the fire season for one or more years.
+-   **Map Explorer** — A **Monthly view** (where fires occurred, with an interactive Leaflet map and GeoJSON export), an **Annual view** (cumulative burn across a full year), and a **Fire Return Period** view (how often each area tends to burn).
+
+### Scenario Explorer
+
+-   **Land Cover Productivity** — Compares productivity and year-to-year stability across land cover classes.
+-   **Agricultural Monitoring** — Tracks NDVI for crops and rangeland.
+-   **Anomaly Resilience** — Examines how vegetation responded during an anomalous year.
+
+### AI Assistant
+
+-   Ask questions in natural language about vegetation trends, fire patterns, and land cover changes.
+-   Multi-provider LLM backend (Anthropic Claude or OpenAI GPT), selectable in the settings panel.
+-   A tool-calling agent that queries the Data API and renders results inline as **Plotly charts, tables, interactive Leaflet maps, and side-by-side comparison images**.
+-   Responses render Markdown and LaTeX (via MathJax).
+-   Uses a server-configured API key when available, or a user-provided key entered in the UI (kept for the session only, never stored).
 
 ### General
 
 -   Interactive map showing the selected Area of Interest (AoI).
+-   Multilingual UI (English, Dutch, French).
 -   Figures are cached after first generation to speed up repeated requests.
 -   Multiple satellite data sources and spatial resolutions supported.
 
 ## Supported Project Areas
 
-| Area           | Country  | Available in         |
-|----------------|----------|----------------------|
-| Mponda         | Zambia   | NDVI Explorer        |
-| Ancares Courel | Spain    | NDVI Explorer        |
-| Stara Planina  | Bulgaria | NDVI Explorer        |
-| Kasigau        | Kenya    | NDVI Explorer        |
-| West Lunga     | Zambia   | Burned Area Explorer |
+| Area           | Country  | Available in                                  |
+|----------------|----------|-----------------------------------------------|
+| Mponda         | Zambia   | NDVI Explorer, Scenario Explorer, Burned Area |
+| West Lunga     | Zambia   | NDVI Explorer, Scenario Explorer, Burned Area |
+| Ancares Courel | Spain    | NDVI Explorer, Scenario Explorer              |
+| Stara Planina  | Bulgaria | NDVI Explorer, Scenario Explorer              |
+| Kasigau        | Kenya    | NDVI Explorer, Scenario Explorer              |
 
 ## Data Sources & Resolutions
 
@@ -40,27 +60,40 @@ A [Shiny](https://shiny.posit.co/) web application by [Sensing Clues](https://ww
 
 Data is available from 2015 onwards.
 
+## Data Access (hot/warm/cold)
+
+The app resolves data through a three-tier fallback so it stays responsive even if a tier is unavailable:
+
+1.  **Hot path — Data API.** A companion FastAPI service serves on-demand time series, grids, and geometry. Configured via the `NDVI_API_URL` environment variable (defaults to `http://localhost:8000`) with a hard 2-second timeout.
+2.  **Warm path — Parquet.** Pre-computed summaries read from local Parquet files.
+3.  **Cold path — Raster.** Raw raster (TIF) files read and processed directly.
+
+If the Data API is unreachable, the app silently falls back to the warm and then cold paths, so all explorers continue to work against local data. The AI Assistant requires the Data API (hot path).
+
 ## Project Structure
 
-```         
+```
 app/
-├── app.R                  # Entry point
-├── global.R               # Library loading and global variables
-├── server.R               # Shiny server logic
-├── ui.R                   # Top-level UI definition
+├── app.R                     # Entry point
+├── global.R                  # Library loading, global variables, and API/data config
+├── server.R                  # Shiny server logic
+├── ui.R                      # Top-level UI definition
 ├── ui/
-│   ├── mod_header_ui.R    # Header module
-│   ├── mod_sidebar_ui.R   # Sidebar controls module
-│   └── mod_body_ui.R      # Main body/tab content module
+│   ├── mod_header_ui.R       # Header module
+│   ├── mod_sidebar_ui.R      # Sidebar controls module
+│   ├── mod_body_ui.R         # Main body/tab content module
+│   └── mod_busy_spinner_ui.R # Busy-spinner module
 ├── src/
-│   ├── utilities.R        # Helper functions
-│   ├── visualization.R    # Visualization utilities
-│   └── generate_plots.R   # Plot generation functions
-├── translations.json      # UI translation strings (EN/NL/FR)
-├── DESCRIPTION            # R package dependencies (deprecated)
+│   ├── utilities.R           # Helper functions (incl. API/geometry helpers)
+│   ├── visualization.R       # Visualization utilities and hot-path builders
+│   ├── generate_plots.R      # Plot generation functions
+│   ├── scenario_analysis.R   # Scenario Explorer analyses
+│   └── agent_renderers.R     # Renders AI Assistant charts/tables/maps/images
+├── translations.json         # UI translation strings (EN/NL/FR)
+├── DESCRIPTION               # R package dependencies (deprecated)
 └── www/
-    ├── figures/           # Cached generated figures
-    └── style.css          # Custom app styling
+    ├── figures/              # Cached generated figures
+    └── style.css             # Custom app styling
 ```
 
 ## Installation & Running
@@ -72,11 +105,11 @@ app/
 
 ``` r
 install.packages(c(
-  "dplyr", "future", "ggplot2", "ipc", "jsonlite",
-  "leaflet", "leaflet.extras", "lubridate", "promises",
-  "raster", "shiny", "shinybusy", "shiny.i18n", "shinyjs",
-  "shinyTree", "shinyWidgets", "sf", "terra", "tidyr",
-  "trend", "plotly", "htmlwidgets", "devtools"
+  "dplyr", "future", "ggplot2", "htmltools", "ipc", "jsonlite",
+  "leaflet", "leaflet.extras2", "lubridate", "promises", "raster",
+  "RColorBrewer", "shiny", "shinybusy", "shiny.i18n", "shinyjs",
+  "shinyTree", "shinyWidgets", "sf", "terra", "tidyr", "trend",
+  "plotly", "htmlwidgets", "arrow", "httr", "commonmark", "devtools"
 ))
 ```
 
@@ -95,11 +128,29 @@ shiny::runApp("app")
 
 Or open `app.R` in RStudio and click **Run App**.
 
+### Configure the Data API and AI Assistant
+
+The hot path and the AI Assistant talk to the companion Data API. Point the app at a running instance via an environment variable (otherwise it defaults to `http://localhost:8000` and silently falls back to local data):
+
+``` r
+# In R, before launching the app, or in .Renviron
+Sys.setenv(NDVI_API_URL = "https://your-data-api-host")
+```
+
+The AI Assistant needs an LLM API key. Either configure a server-side key as an environment variable on the Data API host:
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+```
+
+…or leave them unset and let each user paste their own key into the Assistant settings panel (used for that session only, never stored).
+
 ### Data Setup
 
 The app reads input data from a folder with the following structure:
 
-```         
+```
 <data_dir>/
 ├── AoI/
 │   └── AoI_<project_area>.geojson  # Area of Interest boundaries

--- a/app/global.R
+++ b/app/global.R
@@ -23,6 +23,7 @@ library(trend)
 library(plotly)
 library(htmlwidgets)
 library(arrow)
+library(httr)
 
 # load functions specific for this app
 source("src/utilities.R")
@@ -56,6 +57,12 @@ cache_dir <- file.path("www/.cache")
 # Set test folder structure (uncomment when working locally with a different folder structure)
 #test_dir <- file.path("www/data")
 #data_dir <- test_dir
+
+# --- API (hot path) configuration --------------------------------------------
+# Set NDVI_API_URL to point at the FastAPI server. Defaults to localhost so the
+# hot path is attempted by default; on timeout the app falls back to Parquet.
+API_BASE_URL     <- Sys.getenv("NDVI_API_URL", unset = "http://localhost:8000")
+API_TIMEOUT_SECS <- 2   # hard requirement — do not increase
 
 # --- Multilingual setup -------------------------------------------------------
 i18n <- Translator$new(translation_json_path = "translations.json")

--- a/app/global.R
+++ b/app/global.R
@@ -24,11 +24,13 @@ library(plotly)
 library(htmlwidgets)
 library(arrow)
 library(httr)
+library(commonmark)
 
 # load functions specific for this app
 source("src/utilities.R")
 source("src/visualization.R")
 source("src/generate_plots.R")
+source("src/agent_renderers.R")
 
 # as part of future package we need to define where the future is executed,
 # multisession means we are launching background R processes on the same machine

--- a/app/global.R
+++ b/app/global.R
@@ -22,6 +22,7 @@ library(tidyr)
 library(trend)
 library(plotly)
 library(htmlwidgets)
+library(arrow)
 
 # load functions specific for this app
 source("src/utilities.R")

--- a/app/server.R
+++ b/app/server.R
@@ -214,9 +214,46 @@ server <- function(input, output, session) {
     country_name <- input$country
     resolution   <- input$resolution
 
-    # HOT PATH stub
-    # api_data <- try_api_call(...)
-    # if (!is.null(api_data)) return(api_data)
+    # HOT PATH: the /ndvi/by-landcover endpoint is single-year, but the scenario
+    # plots need every available year. Fetch one year at a time and bind. Only
+    # use the API result if EVERY expected year came back (same coverage guard as
+    # the warm path below); otherwise fall through silently. The first call fails
+    # fast when the API is down (connection refused), so fallback stays quick.
+    sr <- get_sensor_resolution(resolution)
+    api_years <- tryCatch(
+      .scenario_avail_years(data_dir, country_name, resolution),
+      error = function(e) integer(0)
+    )
+    if (!is.null(sr) && length(api_years) > 0) {
+      # Stop at the first failed year so a down API costs one timeout, not one
+      # per year. Need every year for the scenario plots, so any miss = fall back.
+      api_parts <- vector("list", length(api_years))
+      api_ok    <- TRUE
+      for (i in seq_along(api_years)) {
+        d <- try_api_call(
+          endpoint = "/api/v1/ndvi/by-landcover",
+          params   = list(aoi = country_name, sensor = sr$sensor,
+                          resolution = sr$resolution, year = api_years[i])
+        )
+        if (is.null(d) || !all(c("year", "month", "land_cover", "mean_ndvi") %in% names(d))) {
+          api_ok <- FALSE
+          break
+        }
+        api_parts[[i]] <- d[, c("year", "month", "land_cover", "mean_ndvi")]
+      }
+      if (api_ok) {
+        df <- do.call(rbind, api_parts)
+        df$year  <- as.integer(df$year)
+        df$month <- as.integer(df$month)
+        df <- .drop_empty_lc_classes(df)
+        if (nrow(df) > 0) {
+          message("=== scenario_ndvi_data: hot path (API), years=", length(api_years),
+                  " rows=", nrow(df))
+          attr(df, "data_source") <- "api"
+          return(df)
+        }
+      }
+    }
 
     # WARM PATH: read pre-processed ndvi_monthly_by_class.parquet
     pq_path <- get_parquet_path(country_name, resolution, "ndvi_monthly_by_class")
@@ -570,7 +607,7 @@ server <- function(input, output, session) {
         switch(data_source_rv(),
           "parquet" = "Data: pre-processed (fast)",
           "tif"     = "Data: computed from raw files",
-          "api"     = "Data: live API",
+          "api"     = "Data: live API (fast)",
           ""
         )
       })
@@ -1167,6 +1204,7 @@ server <- function(input, output, session) {
       lc_ts_plot_obj(lc_result$plot)
       lc_map_bbox_by_stem(lc_result$bbox_by_stem)
       lc_plot_year(end_year)
+      data_source_rv(if (!is.null(lc_result$data_source)) lc_result$data_source else "tif")
       
       htmlwidgets::saveWidget(
         lc_result$plot,
@@ -1494,8 +1532,41 @@ server <- function(input, output, session) {
     res_m          <- as.numeric(gsub("[^0-9]", "", resolution))
     pixel_area_km2 <- (res_m / 1000)^2
 
-    # HOT PATH stub
-    # api_data <- try_api_call(...)
+    # HOT PATH: the /burned-area/daily endpoint takes a single year (int), so
+    # fetch each selected year separately and bind. Stop at the first failed year
+    # (a down API then costs one timeout, not one per year); any miss = fall back.
+    api_parts <- vector("list", length(selected_years))
+    api_ok    <- length(selected_years) > 0
+    for (i in seq_along(selected_years)) {
+      d <- try_api_call(
+        endpoint = "/api/v1/burned-area/daily",
+        params   = list(aoi = country_name, year = selected_years[i])
+      )
+      if (is.null(d) || !all(c("date", "burned_km2", "year") %in% names(d))) {
+        api_ok <- FALSE
+        break
+      }
+      api_parts[[i]] <- d
+    }
+    if (api_ok) {
+      api_daily <- do.call(rbind, api_parts)
+      api_daily$date  <- as.Date(api_daily$date)
+      api_daily$month <- as.integer(format(api_daily$date, "%m"))
+      api_daily <- api_daily[api_daily$month %in% season_months, ]
+      all_daily <- if (nrow(api_daily) > 0) {
+        data.frame(
+          date = api_daily$date,
+          km2  = api_daily$burned_km2,
+          year = as.character(api_daily$year),
+          stringsAsFactors = FALSE
+        )
+      } else NULL
+      ba_daily_plot_obj(plot_ba_daily_activity(all_daily, as.character(selected_years)))
+      error_message_rv(NULL)
+      data_source_rv("api")
+      message("=========== End of Daily Burn Activity Generation (API) =============")
+      return()
+    }
 
     # WARM PATH: read pre-processed ba_daily.parquet
     tryCatch({
@@ -1591,7 +1662,7 @@ server <- function(input, output, session) {
     end_year  <- selected_end$end_year
     
     tryCatch({
-      ba_plot <- generate_ba_timeseries(
+      ba_result <- generate_ba_timeseries(
         country_name    = country_name,
         resolution      = resolution,
         end_year        = end_year,
@@ -1601,7 +1672,8 @@ server <- function(input, output, session) {
         return_plot     = TRUE,
         figure_filename = NULL
       )
-      ba_ts_plot_obj(ba_plot)
+      ba_ts_plot_obj(ba_result$plot)
+      data_source_rv(if (!is.null(ba_result$data_source)) ba_result$data_source else "tif")
       ba_ts_ready(TRUE)
       error_message_rv(NULL)
     }, error = function(e) {

--- a/app/server.R
+++ b/app/server.R
@@ -1950,44 +1950,64 @@ server <- function(input, output, session) {
 
   # ------- BA Annual View reactive + outputs (NEW — hot path only) ----------
 
-  # Per-pixel annual burn frequency from the API; NULL when the API is down.
-  ba_annual_result <- reactive({
+  # Per-pixel annual burn frequency: HOT (annual-grid API) -> COLD (compute from
+  # the monthly burned-area TIFs). Returns a normalised list or NULL if neither
+  # source is available. `source` drives the data label ("api" / "tif").
+  ba_annual_data <- reactive({
     req(input$ba_map_view == "annual")
     req(input$country, input$year)
-    try_api_grid_call(
+
+    aoi_files <- list.files(file.path(data_dir, "AoI"),
+                            pattern = paste0("AoI.*", input$country, ".*\\.geojson$"))
+
+    # HOT PATH
+    raw <- try_api_grid_call(
       "/api/v1/burned-area/annual-grid",
       list(aoi = input$country, year = input$year)
     )
+    if (!is.null(raw)) {
+      aoi_shape <- if (length(aoi_files) > 0)
+        tryCatch(read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), input$country),
+                 error = function(e) NULL) else NULL
+      return(list(source = "api", df = parse_grid_response(raw),
+                  total_burned_km2 = raw$metadata$total_burned_km2, aoi_shape = aoi_shape))
+    }
+
+    # COLD PATH: compute burn frequency from raw TIFs.
+    cold <- tryCatch(
+      compute_ba_annual_cold(data_dir, input$country, input$resolution, input$year),
+      error = function(e) NULL)
+    if (!is.null(cold)) {
+      return(list(source = "tif", df = cold$df,
+                  total_burned_km2 = cold$total_burned_km2, aoi_shape = cold$aoi_shape))
+    }
+    NULL
   })
 
-  observeEvent(ba_annual_result(), {
-    if (!is.null(ba_annual_result())) data_source_rv("api")
+  observeEvent(ba_annual_data(), {
+    d <- ba_annual_data()
+    if (!is.null(d)) data_source_rv(d$source)
   })
 
   output$ba_annual_summary <- renderUI({
     req(input$ba_map_view == "annual")
-    res <- ba_annual_result()
-    if (is.null(res)) {
+    d <- ba_annual_data()
+    if (is.null(d)) {
       return(div(class = "infobox",
                  p(style = "margin:0; color:#C62828;",
-                   "Annual burn map requires the API server to be running.")))
+                   "Annual burn map requires the API server or local burned-area files.")))
     }
-    tot <- res$metadata$total_burned_km2
+    tot <- d$total_burned_km2
     p(style = "color:#555; font-size:0.9em; margin-bottom:10px;",
       paste0("Total burned area in ", input$year, ": ",
-             if (!is.null(tot)) paste0(round(tot, 1), " km2") else "n/a"))
+             if (!is.null(tot) && !is.na(tot)) paste0(round(tot, 1), " km2") else "n/a"))
   })
 
   output$ba_annual_leaflet <- renderLeaflet({
     req(input$ba_map_view == "annual")
-    res <- ba_annual_result()
-    req(!is.null(res))
-    aoi_files <- list.files(file.path(data_dir, "AoI"),
-                            pattern = paste0("AoI.*", input$country, ".*\\.geojson$"))
-    req(length(aoi_files) > 0)
-    aoi_shape <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), input$country)
-    build_ba_annual_leaflet(parse_grid_response(res), aoi_shape, input$year,
-                            res$metadata$total_burned_km2)
+    d <- ba_annual_data()
+    req(!is.null(d), !is.null(d$aoi_shape))
+    build_ba_annual_leaflet(d$df, d$aoi_shape, input$year, d$total_burned_km2)
   })
 
   # ------- Show/hide sidebar year & month when toggling BA map views --------
@@ -2011,6 +2031,35 @@ server <- function(input, output, session) {
       paste0("burned_area_", input$year, "_", match(input$month, month.name), ".geojson")
     },
     content = function(file) {
+      # HOT PATH: fetch the vectorized burned-area GeoJSON from the API.
+      # Single call, so no Windows short-circuit; longer 10s timeout because
+      # server-side vectorization is slower than tabular fetches.
+      api_url <- paste0(API_BASE_URL, "/api/v1/burned-area/monthly-geojson")
+      response <- tryCatch(
+        httr::GET(
+          api_url,
+          query = list(
+            aoi   = input$country,
+            year  = input$year,
+            month = match(input$month, month.name)  # input$month is the name
+          ),
+          httr::timeout(10)
+        ),
+        error = function(e) NULL
+      )
+      if (!is.null(response) && httr::status_code(response) == 200) {
+        content_text <- httr::content(response, "text", encoding = "UTF-8")
+        # The endpoint returns 200 with {"status":"error"} when no data exists,
+        # so only accept a genuine FeatureCollection before writing.
+        parsed <- tryCatch(jsonlite::fromJSON(content_text, simplifyVector = FALSE),
+                           error = function(e) NULL)
+        if (!is.null(parsed) && identical(parsed$type, "FeatureCollection")) {
+          writeLines(content_text, file)
+          return()  # early return — skip cold path
+        }
+      }
+
+      # COLD PATH: copy the pre-generated GeoJSON (existing behaviour, unchanged).
       path <- geojson_export_path_rv()
       req(path, file.exists(path))
       file.copy(path, file, overwrite = TRUE)

--- a/app/server.R
+++ b/app/server.R
@@ -37,10 +37,12 @@ server <- function(input, output, session) {
   
   # Create selector choice sets based on the selected tab (NDVI or BA Explorer)
   countrychoices_rv <- reactiveValues(
-    choice_set =   list(NDVIexplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "Ancares Courel, Spain" = "Spain", 
+    choice_set =   list(NDVIexplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "West Lunga, Zambia" = "Zambia_WL",
+                                            "Ancares Courel, Spain" = "Spain",
                                             "Stara Planina, Bulgaria" = "Bulgaria", "Kasigau, Kenya" = "Kenya"),
                         BAexplorerTab = c("West Lunga, Zambia" = "Zambia_WL", "Mponda, Zambia" = "Zambia_Mponda"),
-                        ScenarioExplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "Ancares Courel, Spain" = "Spain", 
+                        ScenarioExplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "West Lunga, Zambia" = "Zambia_WL",
+                                                "Ancares Courel, Spain" = "Spain",
                                                 "Stara Planina, Bulgaria" = "Bulgaria", "Kasigau, Kenya" = "Kenya")),
     selected_set = list(NDVIexplorerTab = "Zambia_Mponda", 
                         BAexplorerTab = "Zambia_WL",

--- a/app/server.R
+++ b/app/server.R
@@ -796,40 +796,58 @@ server <- function(input, output, session) {
     if (is.null(s) || !isTRUE(ndvi_ts_ready())) return(NULL)
     if (identical(s$view, "annual")) return(NULL)
 
-    # Determine status from long-term trend and current-year condition.
-    status <- if (!is.null(s$smk_p) && !is.na(s$smk_p) && s$smk_p < 0.05 &&
-                  !is.null(s$sen_slope) && !is.na(s$sen_slope) && s$sen_slope < 0) {
-      "Degrading"
-    } else if (!is.null(s$wilcox_p) && !is.na(s$wilcox_p) && s$wilcox_p < 0.05 &&
-               !is.null(s$wilcox_median) && !is.na(s$wilcox_median) && s$wilcox_median < 0) {
-      "Mild stress"
+    # Monthly view status is based entirely on Wilcoxon test:
+    # selected year's monthly NDVI anomalies vs historical monthly average.
+    wilcox_p   <- if (!is.null(s$wilcox_p))      s$wilcox_p      else NA_real_
+    wilcox_med <- if (!is.null(s$wilcox_median))  s$wilcox_median else NA_real_
+
+    status <- if (is.na(wilcox_p)) {
+      "Insufficient data"
+    } else if (wilcox_p < 0.05 && !is.na(wilcox_med) && wilcox_med > 0) {
+      "Above normal"
+    } else if (wilcox_p < 0.05 && !is.na(wilcox_med) && wilcox_med < 0) {
+      "Below normal"
     } else {
-      "Stable"
+      "Within normal range"
     }
+
     status_color <- switch(status,
-      "Stable" = "#4CAF50",
-      "Mild stress" = "#FFC107",
-      "Degrading" = "#F44336",
+      "Above normal"       = "#009E73",
+      "Below normal"       = "#D55E00",
+      "Within normal range" = "#4CAF50",
       "#9E9E9E"
     )
+
+    train_min <- if (!is.null(s$train_year_min)) s$train_year_min else NA_integer_
+    train_max <- if (!is.null(s$train_year_max)) s$train_year_max else NA_integer_
+    test_yr   <- if (!is.null(s$test_year))      s$test_year      else NA_integer_
+    hist_label <- if (!is.na(train_min) && !is.na(train_max)) sprintf("%d–%d", train_min, train_max) else "historical"
+    yr_label   <- if (!is.na(test_yr)) as.character(test_yr) else "this year"
+
     status_explanation <- switch(status,
-      "Stable" = "No significant change detected compared to historical data.",
-      "Mild stress" = "Vegetation health is below its usual range this year.",
-      "Degrading" = "Long-term vegetation health is declining compared to historical data.",
-      "No significant change detected compared to historical data."
+      "Above normal"       = paste0("Monthly vegetation health in ", yr_label,
+                                    " is significantly above the ", hist_label, " historical average."),
+      "Below normal"       = paste0("Monthly vegetation health in ", yr_label,
+                                    " is significantly below the ", hist_label, " historical average."),
+      "Within normal range" = paste0("Monthly vegetation health in ", yr_label,
+                                     " is within the expected range of the ", hist_label, " historical average."),
+      "Not enough monthly data to compare against the historical baseline."
     )
 
-    # Data coverage from available files
-    years_avail <- get_available_years(data_dir, "NDVI", input$country, input$resolution)
-    res_label   <- dplyr::case_when(
+    # Source label
+    res_label <- dplyr::case_when(
       grepl("Sentinel", input$resolution) ~ "Sentinel-2",
       grepl("MODIS",    input$resolution) ~ "MODIS",
       TRUE                                ~ "satellite"
     )
-    coverage <- if (length(years_avail) > 0) {
-      sprintf("Based on %s data from %d to %d", res_label, min(years_avail), max(years_avail))
+
+    # Analysis period: what year is shown vs what baseline was used
+    has_year_range <- !is.na(test_yr) && !is.na(train_min) && !is.na(train_max)
+    analysis_period <- if (has_year_range) {
+      sprintf("%d (%s), compared against %d–%d baseline (%d years)",
+              test_yr, res_label, train_min, train_max, train_max - train_min + 1L)
     } else {
-      "Based on available data"
+      sprintf("%s data", res_label)
     }
 
     # MODIS recommendation when Sentinel-2 is selected
@@ -839,7 +857,7 @@ server <- function(input, output, session) {
       if (length(modis_years) >= 2L) {
         sprintf("Switch to MODIS for a longer-term perspective covering %d–%d.",
                 min(modis_years), max(modis_years))
-      } else ndvi_error_ui(error_msg)
+      } else NULL
     } else NULL
 
     div(
@@ -848,20 +866,25 @@ server <- function(input, output, session) {
         "; padding:12px; margin-bottom:16px; border-radius:4px;"
       ),
       fluidRow(
-        column(4,
-          tags$strong("Overall status:"), tags$br(),
+        column(5,
+          tags$strong(paste0("Vegetation status in ", yr_label, ":")), tags$br(),
           tags$span(
             style = paste0("font-size:1.2em; color:", status_color, "; font-weight:bold;"),
             tags$span(class = "ndvi-status-dot", style = paste0("background:", status_color, ";")),
             status
           ),
           tags$br(),
-          tags$span(style = "font-size:0.92em; color:#333;", status_explanation)
+          tags$span(style = "font-size:0.85em; color:#444;", status_explanation),
+          tags$br(),
+          tags$span(
+            style = "font-size:0.80em; color:#666; font-style:italic; margin-top:4px; display:inline-block;",
+            if (!is.na(wilcox_p)) paste0("Wilcoxon test, p = ", format(round(wilcox_p, 3), nsmall = 3)) else "p-value: N/A"
+          )
         ),
-        column(8,
-          tags$strong("Data coverage:"), tags$br(),
-          tags$span(coverage),
-          if (!is.null(recommendation)) tagList(tags$br(), tags$em(recommendation)) else NULL
+        column(7,
+          tags$strong("Analysis period:"), tags$br(),
+          tags$span(style = "font-size:0.92em;", analysis_period),
+          if (!is.null(recommendation)) tagList(tags$br(), tags$em(style = "font-size:0.85em; color:#555;", recommendation)) else NULL
         )
       )
     )

--- a/app/server.R
+++ b/app/server.R
@@ -660,7 +660,7 @@ server <- function(input, output, session) {
       if (length(aoi_files) == 0) {
         stop("No Area of Interest file found for the selected country.")
       }
-      shape <- sf::st_read(file.path(data_dir, "AoI", aoi_files[[1]]))
+      shape <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), input$country)
       shape <- sf::st_transform(shape, crs = 4326)
       
       aoi_shape_rv(shape) # Update the reactive value with the loaded shape

--- a/app/server.R
+++ b/app/server.R
@@ -2090,6 +2090,16 @@ server <- function(input, output, session) {
   observeEvent(input$year, { current_context$year <- input$year })
   observeEvent(input$tabs, { current_context$tab  <- input$tabs })
 
+  # Hide the data filters (year/month/resolution) on the AI Assistant tab; the
+  # AoI selector + mini-map stay visible (AoI is still passed to the agent).
+  observeEvent(input$tabs, {
+    if (identical(input$tabs, "AIassistantTab")) {
+      shinyjs::hide("sidebar_filters")
+    } else {
+      shinyjs::show("sidebar_filters")
+    }
+  }, ignoreInit = FALSE)
+
   # --- Per-session conversation state (never stored server-side) ---
   session_history  <- reactiveVal(list())   # list of list(role=, content=)
   pending_question <- reactiveVal(NULL)      # set while the agent is processing
@@ -2125,14 +2135,35 @@ server <- function(input, output, session) {
     }
   })
 
-  # --- Context summary shown on the AI tab ---
-  output$context_summary <- renderText({
-    yr <- if (is.null(current_context$year) || is.na(current_context$year)) "—" else current_context$year
-    paste0(
-      current_context$aoi, "\n",
-      current_context$sensor, " ", current_context$resolution, "m\n",
-      "Year: ", yr
-    )
+  # --- Collapsible settings panel state (expanded on first load) ---
+  settings_expanded <- reactiveVal(TRUE)
+  output$settings_expanded <- reactive(settings_expanded())
+  outputOptions(output, "settings_expanded", suspendWhenHidden = FALSE)
+
+  observeEvent(input$toggle_settings, {
+    settings_expanded(!settings_expanded())
+  })
+  observeEvent(settings_expanded(), {
+    updateActionButton(session, "toggle_settings",
+                       label = if (settings_expanded()) "Settings ▲" else "Settings ▼")
+  })
+
+  # Collapsed-state one-line summary: provider + key status.
+  .provider_label <- function(p) {
+    switch(p, anthropic = "Anthropic (Claude)", openai = "OpenAI (GPT-4o)", p)
+  }
+  output$settings_summary <- renderText({
+    prov <- if (!is.null(input$llm_provider)) input$llm_provider else "anthropic"
+    pi   <- providers_info()
+    key_on_server <- !is.null(pi) && isTRUE(pi[[prov]]$server_key_configured)
+    status <- if (!is.null(input$user_api_key) && nzchar(input$user_api_key)) {
+      "API key set ✓"
+    } else if (key_on_server) {
+      "Server key active"
+    } else {
+      "No API key — expand to configure"
+    }
+    paste0(.provider_label(prov), " · ", status)
   })
 
   # --- Conversation display: chat bubbles (user right, agent left) ---

--- a/app/server.R
+++ b/app/server.R
@@ -2117,6 +2117,19 @@ server <- function(input, output, session) {
     trimws(text)
   }
 
+  # Render an assistant reply as HTML: markdown (incl. pipe tables via extensions)
+  # minus the trailing empty <p></p> that commonmark appends.
+  render_markdown_bubble <- function(text) {
+    if (is.null(text)) return(HTML(""))
+    html <- commonmark::markdown_html(text, extensions = TRUE)
+    # Remove all empty / whitespace-only paragraph tags, then any trailing run.
+    html <- gsub("<p>\\s*</p>", "", html, perl = TRUE)
+    html <- gsub("<p>\\n</p>", "", html, perl = TRUE)
+    html <- sub("(\\s*<p>[[:space:]]*</p>\\s*)+$", "", html, perl = TRUE)
+    html <- trimws(html)
+    HTML(html)
+  }
+
   # Unique per-message output IDs (used to register renderers per message).
   ai_output_ids <- function(msg_id) {
     list(
@@ -2124,6 +2137,37 @@ server <- function(input, output, session) {
       table = paste0("ai_table_", msg_id),
       image = paste0("ai_image_", msg_id)
     )
+  }
+
+  # The .ai-chat container is rebuilt by renderUI on every change, and MathJax
+  # loads asynchronously — so a one-shot scroll/typeset can fire before the bubble
+  # exists in the DOM or before MathJax is ready. Poll every 200ms (up to ~6s):
+  # keep scrolling to the bottom, and once MathJax is available, typeset the chat
+  # so any $$...$$ / $...$ LaTeX renders. Stop when the height is stable AND the
+  # formulas have been typeset.
+  ai_scroll_to_bottom <- function() {
+    shinyjs::runjs("
+      (function renderFinish() {
+        var attempt = 0, maxAttempts = 30, lastHeight = -1, typeset = false;
+        var interval = setInterval(function() {
+          attempt++;
+          var c = document.querySelector('.ai-chat');
+          if (c) {
+            if (!typeset && window.MathJax && MathJax.typesetPromise) {
+              typeset = true;
+              MathJax.typesetPromise([c]).then(function() {
+                var cc = document.querySelector('.ai-chat');
+                if (cc) cc.scrollTop = cc.scrollHeight;
+              }).catch(function() {});
+            }
+            c.scrollTop = c.scrollHeight;
+            if (c.scrollHeight === lastHeight && typeset) { clearInterval(interval); }
+            lastHeight = c.scrollHeight;
+          }
+          if (attempt >= maxAttempts) clearInterval(interval);
+        }, 200);
+      })();
+    ")
   }
 
   # Register a renderPlotly / renderTable output per assistant message that
@@ -2142,6 +2186,7 @@ server <- function(input, output, session) {
           output[[local_id]] <- plotly::renderPlotly({ render_agent_chart(local_chart) })
         })
         registered_outputs(c(registered_outputs(), ids$chart))
+        ai_scroll_to_bottom()  # re-scroll once the chart has rendered
       }
 
       if (!is.null(m$table) && !(ids$table %in% registered_outputs())) {
@@ -2152,6 +2197,7 @@ server <- function(input, output, session) {
                                             striped = TRUE, hover = TRUE, bordered = TRUE)
         })
         registered_outputs(c(registered_outputs(), ids$table))
+        ai_scroll_to_bottom()  # re-scroll once the table has rendered
       }
     }
   })
@@ -2231,7 +2277,7 @@ server <- function(input, output, session) {
       role <- if (identical(m$role, "user")) "user" else "agent"
       # Agent replies are markdown -> render to HTML; user input stays plain text.
       bubble_content <- if (identical(m$role, "assistant")) {
-        HTML(commonmark::markdown_html(m$content))
+        render_markdown_bubble(m$content)
       } else {
         m$content
       }
@@ -2316,30 +2362,52 @@ server <- function(input, output, session) {
                  text   = httr::content(resp, "text", encoding = "UTF-8"))
           }),
           onFulfilled = function(res) {
-            answer      <- fallback
+            warn        <- "⚠️ "   # warning sign + VS16
             agent_chart <- NULL
             agent_table <- NULL
-            if (isTRUE(res$status == 200)) {
+            status      <- res$status
+
+            if (isTRUE(status == 401)) {
+              answer <- paste0(warn, "**Authentication error** — your API key appears to be ",
+                               "invalid or expired. Please check your key in the Settings panel above.")
+            } else if (isTRUE(status == 400)) {
+              answer <- paste0(warn, "**Request error** — the selected AI provider could not ",
+                               "process the request. Try switching provider in Settings.")
+            } else if (isTRUE(status >= 500)) {
+              answer <- paste0(warn, "**Server error** — the data service is temporarily ",
+                               "unavailable. Please try again in a moment.")
+            } else if (isTRUE(status == 200)) {
               parsed <- tryCatch(jsonlite::fromJSON(res$text, simplifyVector = FALSE),
                                  error = function(e) NULL)
-              if (!is.null(parsed) && !is.null(parsed$response) && nzchar(parsed$response)) {
+              if (!is.null(parsed) && !is.null(parsed$error) && nzchar(parsed$error)) {
+                answer <- paste0(warn, parsed$error)
+              } else if (!is.null(parsed) && !is.null(parsed$response) && nzchar(parsed$response)) {
                 answer      <- strip_agent_tags(parsed$response)
-                agent_chart <- parsed$chart   # NULL if absent; stored as-is
-                agent_table <- parsed$table   # NULL if absent; stored as-is
+                agent_chart <- parsed$chart
+                agent_table <- parsed$table
+              } else {
+                answer <- paste0(warn, "The assistant returned an empty response. Please try again.")
               }
+            } else {
+              answer <- paste0(warn, "Could not reach the data service. ",
+                               "Please check your connection and try again.")
             }
+
             n <- msg_counter() + 1; msg_counter(n); mid <- paste0("msg_", n)
             session_history(c(session_history(), list(
               list(role = "user",      content = q,      chart = NULL,        table = NULL,        msg_id = mid),
               list(role = "assistant", content = answer, chart = agent_chart, table = agent_table, msg_id = mid)
             )))
+            ai_scroll_to_bottom()  # scroll + typeset LaTeX once the bubble renders
           }
         ),
         onRejected = function(e) {
           n <- msg_counter() + 1; msg_counter(n); mid <- paste0("msg_", n)
+          err <- paste0("⚠️ Could not reach the data service. ",
+                        "Please check your connection and try again.")
           session_history(c(session_history(), list(
-            list(role = "user",      content = q,        chart = NULL, table = NULL, msg_id = mid),
-            list(role = "assistant", content = fallback, chart = NULL, table = NULL, msg_id = mid)
+            list(role = "user",      content = q,   chart = NULL, table = NULL, msg_id = mid),
+            list(role = "assistant", content = err, chart = NULL, table = NULL, msg_id = mid)
           )))
         }
       ),

--- a/app/server.R
+++ b/app/server.R
@@ -39,7 +39,7 @@ server <- function(input, output, session) {
   countrychoices_rv <- reactiveValues(
     choice_set =   list(NDVIexplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "Ancares Courel, Spain" = "Spain", 
                                             "Stara Planina, Bulgaria" = "Bulgaria", "Kasigau, Kenya" = "Kenya"),
-                        BAexplorerTab = c("West Lunga, Zambia" = "Zambia_WL"),
+                        BAexplorerTab = c("West Lunga, Zambia" = "Zambia_WL", "Mponda, Zambia" = "Zambia_Mponda"),
                         ScenarioExplorerTab = c("Mponda, Zambia" = "Zambia_Mponda", "Ancares Courel, Spain" = "Spain", 
                                                 "Stara Planina, Bulgaria" = "Bulgaria", "Kasigau, Kenya" = "Kenya")),
     selected_set = list(NDVIexplorerTab = "Zambia_Mponda", 

--- a/app/server.R
+++ b/app/server.R
@@ -2179,7 +2179,12 @@ server <- function(input, output, session) {
       if (!identical(m$role, "assistant")) next
       ids <- ai_output_ids(m$msg_id)
 
-      if (!is.null(m$chart) && !(ids$chart %in% registered_outputs())) {
+      .leaflet_types <- c("delta_map", "frp_map", "burned_area_map")
+
+      # Plotly: every chart type EXCEPT Leaflet maps / static comparison images.
+      if (!is.null(m$chart) &&
+          !(m$chart$type %in% c(.leaflet_types, "comparison_image")) &&
+          !(ids$chart %in% registered_outputs())) {
         local({
           local_chart <- m$chart
           local_id    <- ids$chart
@@ -2187,6 +2192,31 @@ server <- function(input, output, session) {
         })
         registered_outputs(c(registered_outputs(), ids$chart))
         ai_scroll_to_bottom()  # re-scroll once the chart has rendered
+      }
+
+      # Leaflet maps (delta_map / frp_map / burned_area_map) on ids$chart.
+      if (!is.null(m$chart) && m$chart$type %in% .leaflet_types &&
+          !(ids$chart %in% registered_outputs())) {
+        local({
+          local_chart <- m$chart
+          local_id    <- ids$chart
+          output[[local_id]] <- renderLeaflet({ render_agent_leaflet(local_chart) })
+        })
+        registered_outputs(c(registered_outputs(), ids$chart))
+        ai_scroll_to_bottom()
+      }
+
+      # Static comparison image (PNG) on ids$image.
+      if (!is.null(m$chart) && identical(m$chart$type, "comparison_image") &&
+          !(ids$image %in% registered_outputs())) {
+        local({
+          local_chart <- m$chart
+          local_id    <- ids$image
+          output[[local_id]] <- renderImage({ render_agent_image(local_chart, local_id) },
+                                            deleteFile = FALSE)
+        })
+        registered_outputs(c(registered_outputs(), ids$image))
+        ai_scroll_to_bottom()
       }
 
       if (!is.null(m$table) && !(ids$table %in% registered_outputs())) {
@@ -2292,11 +2322,18 @@ server <- function(input, output, session) {
         ids   <- ai_output_ids(m$msg_id)
         parts <- list()
         if (!is.null(m$chart)) {
-          parts[[length(parts) + 1]] <- div(
-            class = "ai-output-row ai-output-chart",
-            if (!is.null(m$chart$title)) strong(m$chart$title),
-            plotly::plotlyOutput(ids$chart, height = "350px")
-          )
+          ctype <- m$chart$type %||% ""
+          ctitle <- if (!is.null(m$chart$title)) strong(m$chart$title)
+          parts[[length(parts) + 1]] <- if (ctype %in% c("delta_map", "frp_map", "burned_area_map")) {
+            div(class = "ai-output-row ai-output-map",
+                ctitle, leafletOutput(ids$chart, height = "400px"))
+          } else if (identical(ctype, "comparison_image")) {
+            div(class = "ai-output-row ai-output-image",
+                ctitle, imageOutput(ids$image, height = "auto"))
+          } else {
+            div(class = "ai-output-row ai-output-chart",
+                ctitle, plotly::plotlyOutput(ids$chart, height = "350px"))
+          }
         }
         if (!is.null(m$table)) {
           parts[[length(parts) + 1]] <- div(

--- a/app/server.R
+++ b/app/server.R
@@ -2148,21 +2148,74 @@ server <- function(input, output, session) {
   ai_scroll_to_bottom <- function() {
     shinyjs::runjs("
       (function renderFinish() {
-        var attempt = 0, maxAttempts = 30, lastHeight = -1, typeset = false;
+        // window.__etsUserHeld is a single shared guard (multiple concurrent
+        // scroll loops can run for one response). It turns true only when the
+        // user scrolls UP away from the bottom, so we never yank them back down
+        // while they read earlier messages. Reset on each new response below.
+        window.__etsUserHeld = false;
+        var attempt = 0, maxAttempts = 60;       // 60 * 200ms = 12s safety window
+        var lastHeight = -1, stableTicks = 0;
+        var typesetStarted = false, typesetDone = false;
+
+        function stick(c) { if (!window.__etsUserHeld) c.scrollTop = c.scrollHeight; }
+
+        // Re-scroll when any image finishes loading (comparison PNGs, leaflet
+        // tiles). New images are added late, so we re-hook on every tick.
+        function hookImages(c) {
+          var imgs = c.querySelectorAll('img');
+          for (var i = 0; i < imgs.length; i++) {
+            if (!imgs[i].__etsHook && !imgs[i].complete) {
+              imgs[i].__etsHook = true;
+              imgs[i].addEventListener('load', function() {
+                var cc = document.querySelector('.ai-chat');
+                if (cc) stick(cc);
+              }, { once: true });
+            }
+          }
+        }
+
+        // Bind a scroll listener once per (rebuilt) container to detect a
+        // deliberate scroll-up. Programmatic scroll-to-bottom lands near the
+        // bottom (distance ~0), so it won't falsely trip this.
+        function bindScroll(c) {
+          if (c.__etsBound) return;
+          c.__etsBound = true;
+          c.addEventListener('scroll', function() {
+            var distance = c.scrollHeight - c.scrollTop - c.clientHeight;
+            window.__etsUserHeld = distance > 120;
+          });
+        }
+
         var interval = setInterval(function() {
           attempt++;
           var c = document.querySelector('.ai-chat');
           if (c) {
-            if (!typeset && window.MathJax && MathJax.typesetPromise) {
-              typeset = true;
-              MathJax.typesetPromise([c]).then(function() {
-                var cc = document.querySelector('.ai-chat');
-                if (cc) cc.scrollTop = cc.scrollHeight;
-              }).catch(function() {});
+            bindScroll(c);
+            hookImages(c);
+
+            if (!typesetStarted) {
+              if (window.MathJax && MathJax.typesetPromise) {
+                typesetStarted = true;
+                MathJax.typesetPromise([c]).then(function() {
+                  typesetDone = true;
+                  var cc = document.querySelector('.ai-chat');
+                  if (cc) stick(cc);
+                }).catch(function() { typesetDone = true; });
+              } else if (window.MathJax === undefined) {
+                typesetDone = true;   // no MathJax on the page: nothing to wait for
+              }
             }
-            c.scrollTop = c.scrollHeight;
-            if (c.scrollHeight === lastHeight && typeset) { clearInterval(interval); }
+
+            stick(c);
+
+            if (c.scrollHeight === lastHeight) { stableTicks++; } else { stableTicks = 0; }
             lastHeight = c.scrollHeight;
+
+            // Stop only once the height has held steady for ~1s (covers async
+            // charts/maps/images settling) AND MathJax has finished.
+            if (stableTicks >= 5 && (typesetDone || !typesetStarted && attempt > 3)) {
+              clearInterval(interval);
+            }
           }
           if (attempt >= maxAttempts) clearInterval(interval);
         }, 200);

--- a/app/server.R
+++ b/app/server.R
@@ -2101,8 +2101,30 @@ server <- function(input, output, session) {
   }, ignoreInit = FALSE)
 
   # --- Per-session conversation state (never stored server-side) ---
-  session_history  <- reactiveVal(list())   # list of list(role=, content=)
+  # Each entry: list(role, content, chart=NULL|list, table=NULL|list, msg_id).
+  session_history  <- reactiveVal(list())
   pending_question <- reactiveVal(NULL)      # set while the agent is processing
+  msg_counter      <- reactiveVal(0)         # increments once per exchange (pair)
+
+  # Strip <chart>{...}</chart> / <table>{...}</table> blocks from the display text
+  # (the structured chart/table come back as separate response fields).
+  strip_agent_tags <- function(text) {
+    if (is.null(text)) return("")
+    text <- gsub("<chart>\\s*\\{[^}]*(?:\\{[^}]*\\}[^}]*)*\\}\\s*</chart>",
+                 "", text, perl = TRUE)
+    text <- gsub("<table>\\s*\\{[^}]*(?:\\{[^}]*\\}[^}]*)*\\}\\s*</table>",
+                 "", text, perl = TRUE)
+    trimws(text)
+  }
+
+  # Unique per-message output IDs (used by Steps 2/3 to register renderers).
+  ai_output_ids <- function(msg_id) {
+    list(
+      chart = paste0("ai_chart_", msg_id),
+      table = paste0("ai_table_", msg_id),
+      image = paste0("ai_image_", msg_id)
+    )
+  }
 
   # --- Provider / server-key discovery (GET /agent/providers) ---
   providers_info <- reactive({
@@ -2177,8 +2199,35 @@ server <- function(input, output, session) {
     }
     bubbles <- lapply(msgs, function(m) {
       role <- if (identical(m$role, "user")) "user" else "agent"
-      div(class = paste("ai-row", role),
-          div(class = paste("ai-bubble", role), m$content))
+      bubble <- div(class = paste("ai-row", role),
+                    div(class = paste("ai-bubble", role), m$content))
+
+      # Placeholder row(s) under an assistant message that carries a chart/table.
+      # Real renderers replace these in Steps 2/3.
+      placeholder <- NULL
+      if (identical(m$role, "assistant") &&
+          (!is.null(m$chart) || !is.null(m$table))) {
+        ids   <- ai_output_ids(m$msg_id)
+        parts <- list()
+        if (!is.null(m$chart)) {
+          parts[[length(parts) + 1]] <- div(
+            class = "ai-output-row ai-output-placeholder",
+            id    = paste0(ids$chart, "_container"),
+            if (!is.null(m$chart$title)) strong(m$chart$title),
+            p(paste0("[", m$chart$type, " chart — rendering in next step]"))
+          )
+        }
+        if (!is.null(m$table)) {
+          parts[[length(parts) + 1]] <- div(
+            class = "ai-output-row ai-output-placeholder",
+            id    = paste0(ids$table, "_container"),
+            if (!is.null(m$table$title)) strong(m$table$title),
+            p(paste0("[", m$table$type, " table — rendering in next step]"))
+          )
+        }
+        placeholder <- do.call(tagList, parts)
+      }
+      tagList(bubble, placeholder)
     })
     if (!is.null(pend)) {
       bubbles <- c(bubbles, list(
@@ -2233,24 +2282,30 @@ server <- function(input, output, session) {
                  text   = httr::content(resp, "text", encoding = "UTF-8"))
           }),
           onFulfilled = function(res) {
-            answer <- fallback
+            answer      <- fallback
+            agent_chart <- NULL
+            agent_table <- NULL
             if (isTRUE(res$status == 200)) {
               parsed <- tryCatch(jsonlite::fromJSON(res$text, simplifyVector = FALSE),
                                  error = function(e) NULL)
               if (!is.null(parsed) && !is.null(parsed$response) && nzchar(parsed$response)) {
-                answer <- parsed$response
+                answer      <- strip_agent_tags(parsed$response)
+                agent_chart <- parsed$chart   # NULL if absent; stored as-is
+                agent_table <- parsed$table   # NULL if absent; stored as-is
               }
             }
+            n <- msg_counter() + 1; msg_counter(n); mid <- paste0("msg_", n)
             session_history(c(session_history(), list(
-              list(role = "user",      content = q),
-              list(role = "assistant", content = answer)
+              list(role = "user",      content = q,      chart = NULL,        table = NULL,        msg_id = mid),
+              list(role = "assistant", content = answer, chart = agent_chart, table = agent_table, msg_id = mid)
             )))
           }
         ),
         onRejected = function(e) {
+          n <- msg_counter() + 1; msg_counter(n); mid <- paste0("msg_", n)
           session_history(c(session_history(), list(
-            list(role = "user",      content = q),
-            list(role = "assistant", content = fallback)
+            list(role = "user",      content = q,        chart = NULL, table = NULL, msg_id = mid),
+            list(role = "assistant", content = fallback, chart = NULL, table = NULL, msg_id = mid)
           )))
         }
       ),
@@ -2265,6 +2320,7 @@ server <- function(input, output, session) {
   observeEvent(input$clear_history, {
     session_history(list())
     pending_question(NULL)
+    msg_counter(0)
   })
 
 } # END SERVER

--- a/app/server.R
+++ b/app/server.R
@@ -2117,7 +2117,7 @@ server <- function(input, output, session) {
     trimws(text)
   }
 
-  # Unique per-message output IDs (used by Steps 2/3 to register renderers).
+  # Unique per-message output IDs (used to register renderers per message).
   ai_output_ids <- function(msg_id) {
     list(
       chart = paste0("ai_chart_", msg_id),
@@ -2125,6 +2125,36 @@ server <- function(input, output, session) {
       image = paste0("ai_image_", msg_id)
     )
   }
+
+  # Register a renderPlotly / renderTable output per assistant message that
+  # carries a chart/table ref (once each). render_agent_* live in agent_renderers.R.
+  registered_outputs <- reactiveVal(character(0))
+  observe({
+    history <- session_history()
+    for (m in history) {
+      if (!identical(m$role, "assistant")) next
+      ids <- ai_output_ids(m$msg_id)
+
+      if (!is.null(m$chart) && !(ids$chart %in% registered_outputs())) {
+        local({
+          local_chart <- m$chart
+          local_id    <- ids$chart
+          output[[local_id]] <- plotly::renderPlotly({ render_agent_chart(local_chart) })
+        })
+        registered_outputs(c(registered_outputs(), ids$chart))
+      }
+
+      if (!is.null(m$table) && !(ids$table %in% registered_outputs())) {
+        local({
+          local_table <- m$table
+          local_id    <- ids$table
+          output[[local_id]] <- renderTable({ render_agent_table(local_table) },
+                                            striped = TRUE, hover = TRUE, bordered = TRUE)
+        })
+        registered_outputs(c(registered_outputs(), ids$table))
+      }
+    }
+  })
 
   # --- Provider / server-key discovery (GET /agent/providers) ---
   providers_info <- reactive({
@@ -2199,35 +2229,39 @@ server <- function(input, output, session) {
     }
     bubbles <- lapply(msgs, function(m) {
       role <- if (identical(m$role, "user")) "user" else "agent"
+      # Agent replies are markdown -> render to HTML; user input stays plain text.
+      bubble_content <- if (identical(m$role, "assistant")) {
+        HTML(commonmark::markdown_html(m$content))
+      } else {
+        m$content
+      }
       bubble <- div(class = paste("ai-row", role),
-                    div(class = paste("ai-bubble", role), m$content))
+                    div(class = paste("ai-bubble", role), bubble_content))
 
-      # Placeholder row(s) under an assistant message that carries a chart/table.
-      # Real renderers replace these in Steps 2/3.
-      placeholder <- NULL
+      # Rendered chart/table output under an assistant message that carries refs.
+      # Renderers are registered by the observer above; here we place the outputs.
+      outputs <- NULL
       if (identical(m$role, "assistant") &&
           (!is.null(m$chart) || !is.null(m$table))) {
         ids   <- ai_output_ids(m$msg_id)
         parts <- list()
         if (!is.null(m$chart)) {
           parts[[length(parts) + 1]] <- div(
-            class = "ai-output-row ai-output-placeholder",
-            id    = paste0(ids$chart, "_container"),
+            class = "ai-output-row ai-output-chart",
             if (!is.null(m$chart$title)) strong(m$chart$title),
-            p(paste0("[", m$chart$type, " chart — rendering in next step]"))
+            plotly::plotlyOutput(ids$chart, height = "350px")
           )
         }
         if (!is.null(m$table)) {
           parts[[length(parts) + 1]] <- div(
-            class = "ai-output-row ai-output-placeholder",
-            id    = paste0(ids$table, "_container"),
+            class = "ai-output-row ai-output-table",
             if (!is.null(m$table$title)) strong(m$table$title),
-            p(paste0("[", m$table$type, " table — rendering in next step]"))
+            tableOutput(ids$table)
           )
         }
-        placeholder <- do.call(tagList, parts)
+        outputs <- do.call(tagList, parts)
       }
-      tagList(bubble, placeholder)
+      tagList(bubble, outputs)
     })
     if (!is.null(pend)) {
       bubbles <- c(bubbles, list(
@@ -2321,6 +2355,7 @@ server <- function(input, output, session) {
     session_history(list())
     pending_question(NULL)
     msg_counter(0)
+    registered_outputs(character(0))
   })
 
 } # END SERVER

--- a/app/server.R
+++ b/app/server.R
@@ -1285,6 +1285,20 @@ server <- function(input, output, session) {
     }
 
     tryCatch({
+      # HOT PATH: per-pixel annual grids from the API; falls through to cold TIF.
+      sr <- get_sensor_resolution(resolution)
+      res <- if (!is.null(sr)) {
+        compute_ndvi_delta_hot(country_name, sr$sensor, sr$resolution, year_a, year_b)
+      } else NULL
+      if (!is.null(res)) {
+        ndvi_annual_result(res)
+        ndvi_annual_ready(TRUE)
+        data_source_rv("api")
+        error_message_rv(NULL)
+        return()
+      }
+
+      # COLD PATH: compute annual means from raw TIF rasters (unchanged)
       res <- compute_annual_ndvi_change(year_a, year_b, country_name, resolution, data_dir)
       ndvi_annual_result(res)
       ndvi_annual_ready(TRUE)
@@ -1389,17 +1403,28 @@ server <- function(input, output, session) {
     figure_path <- file.path(figures_dir, figure_filename)
     
     tryCatch({
-      if (!file.exists(figure_path)) {
-        if (!dir.exists(figures_dir)) {
-          dir.create(figures_dir, recursive = TRUE)
+      if (!dir.exists(figures_dir)) {
+        dir.create(figures_dir, recursive = TRUE)
+      }
+      # HOT PATH: build the NDVI facet PNG from per-year monthly grids; falls
+      # through to the cold TIF facet when the API is unavailable.
+      sr_hist <- get_sensor_resolution(resolution)
+      hist_hot <- if (!is.null(sr_hist)) tryCatch(
+        generate_2Dmap_hot(country_name, sr_hist$sensor, sr_hist$resolution,
+                           map_year, map_month, figures_dir, figure_filename),
+        error = function(e) NULL) else NULL
+      if (is.null(hist_hot)) {
+        if (!file.exists(figure_path)) {
+          generate_2Dmap(country_name, resolution, map_year, map_month, figures_dir, data_dir, FALSE, FALSE, figure_filename)
         }
-        generate_2Dmap(country_name, resolution, map_year, map_month, figures_dir, data_dir, FALSE, FALSE, figure_filename)
+      } else {
+        data_source_rv("api")
       }
       output$ndvi_histmap_output <- renderImage({
-        list(src = figure_path, 
+        list(src = figure_path,
              alt = "NDVI 2D map")
       }, deleteFile = FALSE)
-    
+
     }, error = function(e) {
       # Clear server outputs so nothing can re-appear
       ndvi_dm_ready(FALSE)
@@ -1423,6 +1448,33 @@ server <- function(input, output, session) {
     figure_path_dm <- file.path(figures_dir, figure_filename_dm)
 
     tryCatch({
+      # HOT PATH: monthly NDVI anomaly grid (selected month vs same-month
+      # historical baseline) rendered as a live Leaflet. Falls through silently
+      # to the cold saved-HTML iframe below when the API is unavailable.
+      sr_dm <- get_sensor_resolution(resolution)
+      anomaly_raw <- if (!is.null(sr_dm)) try_api_grid_call(
+        "/api/v1/ndvi/monthly-anomaly-grid",
+        list(aoi = country_name, sensor = sr_dm$sensor,
+             resolution = sr_dm$resolution, year = map_year, month = map_month)
+      ) else NULL
+
+      if (!is.null(anomaly_raw)) {
+        anomaly_df <- parse_grid_response(anomaly_raw)
+        output$ndvi_monthly_anomaly_leaflet <- renderLeaflet(
+          plot_monthly_anomaly_leaflet(anomaly_df, map_year, map_month,
+                                       anomaly_raw$metadata$baseline_years)
+        )
+        output$ndvi_delta_map_output <- renderUI({
+          leafletOutput("ndvi_monthly_anomaly_leaflet", height = "500px")
+        })
+        ndvi_dm_ready(TRUE)
+        data_source_rv("api")
+        error_message_rv(NULL)
+        message("=========== End of NDVI Delta Plot Generation (API) =============")
+        return()
+      }
+
+      # COLD PATH: saved delta-map HTML in an iframe (unchanged)
       if (!file.exists(figure_path_dm)) {
         if (!dir.exists(figures_dir)) {
           dir.create(figures_dir, recursive = TRUE)
@@ -1430,16 +1482,16 @@ server <- function(input, output, session) {
         generate_2Dmap(country_name, resolution, map_year, map_month, figures_dir, data_dir, TRUE, FALSE, figure_filename_dm)
       }
       output$ndvi_delta_map_output <- renderUI({
-        tags$iframe(src = paste0("figures/", figure_filename_dm), 
-                    width = "100%", 
-                    height = "500px", 
+        tags$iframe(src = paste0("figures/", figure_filename_dm),
+                    width = "100%",
+                    height = "500px",
                     frameborder = 0)
       })
-      
+
       ndvi_dm_ready(TRUE) # Mark UI as ready when both figures are rendered successfully (renderUI will now return the container)
       data_source_rv("tif")  # delta maps are computed from raw TIF rasters
       error_message_rv(NULL) # Clear any previous error messages
-      
+
     }, error = function(e) {
       # Clear server outputs so nothing can re-appear
       ndvi_dm_ready(FALSE)
@@ -1721,6 +1773,19 @@ server <- function(input, output, session) {
     shinyjs::hide("monthly_leaflet_wrap")
   })
   
+  # Session cache for AoI area (km2) from the API — fetched once per AoI and
+  # reused for the BA facet's percentage-of-study-area labels.
+  .aoi_area_cache <- new.env(parent = emptyenv())
+  ba_aoi_area_km2 <- function(aoi) {
+    key <- as.character(aoi)
+    if (is.null(.aoi_area_cache[[key]])) {
+      a <- get_aoi_area_km2(aoi)
+      assign(key, if (is.null(a)) NA_real_ else a, envir = .aoi_area_cache)
+    }
+    val <- .aoi_area_cache[[key]]
+    if (is.na(val)) NULL else val
+  }
+
   # Observe the Generate Figure button
   observeEvent(input$generate_ba_map_figures, {
     message("=========== Starting Burned Area Map Generation =============")
@@ -1741,31 +1806,36 @@ server <- function(input, output, session) {
     figure_path_bam <- file.path(figures_dir, figure_filename_bam)
     
     tryCatch({
-      if (!file.exists(figure_path_bam)) {
-        if (!dir.exists(figures_dir)) {
-          dir.create(figures_dir, recursive = TRUE)
-        }
-        # Generate figure and create GeoJSON file, store path
-        generate_ba_2Dmap(country_name, resolution, map_year, map_month, figures_dir, data_dir, FALSE, FALSE, figure_filename_bam)
-        geojson_export_path <- generate_ba_export(country_name, resolution, map_year, map_month, figures_dir, data_dir, figure_filename_bam)
-        
-        # Update reactive values for the download button
-        geojson_export_path_rv(geojson_export_path)
-        map_generated(TRUE)
+      if (!dir.exists(figures_dir)) {
+        dir.create(figures_dir, recursive = TRUE)
       }
+      # HOT PATH: build the BA facet PNG from per-year monthly grids; falls
+      # through to the cold TIF facet when the API is unavailable.
+      ba_hot <- tryCatch(
+        generate_ba_2Dmap_hot(country_name, map_year, map_month, figures_dir,
+                              figure_filename_bam, ba_aoi_area_km2(country_name)),
+        error = function(e) NULL)
+      if (is.null(ba_hot) && !file.exists(figure_path_bam)) {
+        generate_ba_2Dmap(country_name, resolution, map_year, map_month, figures_dir, data_dir, FALSE, FALSE, figure_filename_bam)
+      }
+
+      # GeoJSON export stays on the COLD path (needed by the download button).
+      geojson_export_path <- file.path(figures_dir, paste0(tools::file_path_sans_ext(figure_filename_bam), ".geojson"))
+      if (!file.exists(geojson_export_path)) {
+        geojson_export_path <- generate_ba_export(country_name, resolution, map_year, map_month, figures_dir, data_dir, figure_filename_bam)
+      }
+      geojson_export_path_rv(geojson_export_path)
+      map_generated(TRUE)
+
       output$ba_map_output <- renderImage({
         list(src = figure_path_bam,
              width = "100%",
              alt = "Burned Area 2D map")
       }, deleteFile = FALSE)
-      
-      # Create GeoJSON export path (same logic as in the function) and update reactive values
-      geojson_export_path <- file.path(figures_dir, paste0(tools::file_path_sans_ext(figure_filename_bam), ".geojson"))
-      geojson_export_path_rv(geojson_export_path)
-      
+
       map_generated(TRUE) # Mark map generated as TRUE to enable the GeoJSON download button
       error_message_rv(NULL) # Clear any previous error messages
-      
+
     }, error = function(e) {
       ba_map_ready(FALSE)
       error_message_rv(e$message)
@@ -1780,27 +1850,50 @@ server <- function(input, output, session) {
     
     #### BA interactive Leaflet map (monthly footprint)
     tryCatch({
-      # Capture current values for the renderer (avoids reactive dependency)
+      # HOT PATH: build the interactive leaflet from the burned-area monthly grid
+      # (pixels as markers). Falls through to the GeoJSON-based leaflet when the
+      # API is unavailable. The static PNG + GeoJSON download stay on cold path.
+      ba_grid_raw <- try_api_grid_call(
+        "/api/v1/burned-area/monthly-grid",
+        list(aoi = country_name, year = map_year, month = map_month)
+      )
+      ba_leaflet_source <- "tif"
+
       local({
         captured_geojson <- geojson_export_path_rv()
         captured_year    <- map_year
         captured_month   <- map_month
         captured_country <- country_name
+        captured_grid    <- ba_grid_raw
 
-        output$ba_monthly_leaflet <- renderLeaflet({
-          build_ba_monthly_leaflet(
-            geojson_path = captured_geojson,
-            data_dir     = data_dir,
-            country      = captured_country,
-            year         = captured_year,
-            month_num    = captured_month
-          )
-        })
+        if (!is.null(captured_grid)) {
+          ba_leaflet_source <<- "api"
+          ba_df       <- parse_grid_response(captured_grid)
+          burned_km2  <- captured_grid$metadata$burned_km2
+          aoi_files   <- list.files(file.path(data_dir, "AoI"),
+                                    pattern = paste0("AoI.*", captured_country, ".*\\.geojson$"))
+          aoi_shape   <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), captured_country)
+          output$ba_monthly_leaflet <- renderLeaflet({
+            build_ba_monthly_leaflet_grid(ba_df, aoi_shape, captured_year,
+                                          captured_month, burned_km2)
+          })
+        } else {
+          output$ba_monthly_leaflet <- renderLeaflet({
+            build_ba_monthly_leaflet(
+              geojson_path = captured_geojson,
+              data_dir     = data_dir,
+              country      = captured_country,
+              year         = captured_year,
+              month_num    = captured_month
+            )
+          })
+        }
       })
 
       shinyjs::show("monthly_leaflet_wrap")
       ba_map_ready(TRUE)
-      data_source_rv("tif")  # static burned-area map is computed from raw TIF rasters
+      # "api" when the interactive map came from the grid, else cold TIF/GeoJSON.
+      data_source_rv(ba_leaflet_source)
       error_message_rv(NULL)
     }, error = function(e) {
       ba_map_ready(FALSE)
@@ -1855,11 +1948,56 @@ server <- function(input, output, session) {
              " (", result$n_years, " year", ifelse(result$n_years == 1, "", "s"), ")"))
   })
 
+  # ------- BA Annual View reactive + outputs (NEW — hot path only) ----------
+
+  # Per-pixel annual burn frequency from the API; NULL when the API is down.
+  ba_annual_result <- reactive({
+    req(input$ba_map_view == "annual")
+    req(input$country, input$year)
+    try_api_grid_call(
+      "/api/v1/burned-area/annual-grid",
+      list(aoi = input$country, year = input$year)
+    )
+  })
+
+  observeEvent(ba_annual_result(), {
+    if (!is.null(ba_annual_result())) data_source_rv("api")
+  })
+
+  output$ba_annual_summary <- renderUI({
+    req(input$ba_map_view == "annual")
+    res <- ba_annual_result()
+    if (is.null(res)) {
+      return(div(class = "infobox",
+                 p(style = "margin:0; color:#C62828;",
+                   "Annual burn map requires the API server to be running.")))
+    }
+    tot <- res$metadata$total_burned_km2
+    p(style = "color:#555; font-size:0.9em; margin-bottom:10px;",
+      paste0("Total burned area in ", input$year, ": ",
+             if (!is.null(tot)) paste0(round(tot, 1), " km2") else "n/a"))
+  })
+
+  output$ba_annual_leaflet <- renderLeaflet({
+    req(input$ba_map_view == "annual")
+    res <- ba_annual_result()
+    req(!is.null(res))
+    aoi_files <- list.files(file.path(data_dir, "AoI"),
+                            pattern = paste0("AoI.*", input$country, ".*\\.geojson$"))
+    req(length(aoi_files) > 0)
+    aoi_shape <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), input$country)
+    build_ba_annual_leaflet(parse_grid_response(res), aoi_shape, input$year,
+                            res$metadata$total_burned_km2)
+  })
+
   # ------- Show/hide sidebar year & month when toggling BA map views --------
 
   observeEvent(input$ba_map_view, {
     if (isTRUE(input$ba_map_view == "frp")) {
       shinyjs::hide("year")
+      shinyjs::hide("month")
+    } else if (isTRUE(input$ba_map_view == "annual")) {
+      shinyjs::show("year")
       shinyjs::hide("month")
     } else {
       shinyjs::show("year")

--- a/app/server.R
+++ b/app/server.R
@@ -706,6 +706,11 @@ server <- function(input, output, session) {
   ndvi_ts_plot_obj <- reactiveVal(NULL)
   ndvi_ts_stats    <- reactiveVal(NULL)
   ndvi_ts_view_rv  <- reactiveVal("monthly")
+  # Translates the "all" sentinel value to NULL so downstream functions treat it as no filter.
+  ndvi_lc_filter <- reactive({
+    val <- input$ndvi_ts_lc_class
+    if (is.null(val) || val == "all") NULL else val
+  })
   
   output$ndvi_ts_plot_output <- plotly::renderPlotly({
     p <- ndvi_ts_plot_obj()
@@ -720,7 +725,7 @@ server <- function(input, output, session) {
     if (is.null(error_msg) && isTRUE(ndvi_ts_ready())) { # If no errors and the reactive flag is TRUE (after successful figure generation), show output, otherwise empty
       div(
         class = "image-fill top-center ndvi-ts-plot-stack",
-        ndvi_anomaly_titles_ui(input$resolution, land_cover_class = input$ndvi_ts_lc_class,
+        ndvi_anomaly_titles_ui(input$resolution, land_cover_class = ndvi_lc_filter(),
                                view = ndvi_ts_view_rv()),
         plotlyOutput("ndvi_ts_plot_output", height = "550px"),
         height = "auto"
@@ -734,14 +739,14 @@ server <- function(input, output, session) {
     s <- ndvi_ts_stats()
     if (is.null(s) || !isTRUE(ndvi_ts_ready())) return(NULL)
     if (!identical(s$view, "monthly")) return(NULL)
-    ndvi_insight_wilcox_card_ui(s, land_cover_class = input$ndvi_ts_lc_class)
+    ndvi_insight_wilcox_card_ui(s, land_cover_class = ndvi_lc_filter())
   })
 
   output$smk_card <- renderUI({
     s <- ndvi_ts_stats()
     if (is.null(s) || !isTRUE(ndvi_ts_ready())) return(NULL)
     if (!identical(s$view, "annual")) return(NULL)
-    ndvi_annual_trend_card_ui(s, land_cover_class = input$ndvi_ts_lc_class)
+    ndvi_annual_trend_card_ui(s, land_cover_class = ndvi_lc_filter())
   })
 
   output$ndvi_data_source_guidance <- renderUI({
@@ -1025,8 +1030,7 @@ server <- function(input, output, session) {
         dir.create(figures_dir, recursive = TRUE)
       }
       
-      lc_class <- if (!is.null(input$ndvi_ts_lc_class) && nzchar(input$ndvi_ts_lc_class))
-        input$ndvi_ts_lc_class else NULL
+      lc_class <- ndvi_lc_filter()
       ts_view <- if (!is.null(input$ndvi_ts_view)) input$ndvi_ts_view else "monthly"
 
       ndvi_result <- generate_timeseries(
@@ -1583,10 +1587,11 @@ server <- function(input, output, session) {
       decreasing    = TRUE
     )
     default_sel <- head(as.character(available_years), 3)
-    selectInput("ba_daily_years", "Select years to compare",
-                choices  = as.character(available_years),
-                selected = default_sel,
-                multiple = TRUE)
+    selectizeInput("ba_daily_years", "Select years to compare",
+                   choices  = as.character(available_years),
+                   selected = default_sel,
+                   multiple = TRUE,
+                   options  = list(plugins = list("remove_button")))
   })
 
   output$ba_daily_plot_container <- renderUI({

--- a/app/server.R
+++ b/app/server.R
@@ -1878,5 +1878,175 @@ server <- function(input, output, session) {
       file.copy(path, file, overwrite = TRUE)
     }
   )
-    
+
+  # ===================================================================================================
+  # AI ASSISTANT (standalone chat tab — Part 3, text only)
+  # ===================================================================================================
+
+  # --- Global app-context tracker: lets the agent know what the user last viewed,
+  #     even though the chat lives on its own tab. Updated as the user changes filters.
+  current_context <- reactiveValues(
+    tab        = "NDVIexplorerTab",
+    aoi        = "Zambia_Mponda",
+    sensor     = "sentinel2",
+    resolution = 1000,
+    year       = NULL
+  )
+  observeEvent(input$country,    { current_context$aoi <- input$country })
+  observeEvent(input$resolution, {
+    sr <- get_sensor_resolution(input$resolution)
+    if (!is.null(sr)) {
+      current_context$sensor     <- sr$sensor
+      current_context$resolution <- sr$resolution
+    }
+  })
+  observeEvent(input$year, { current_context$year <- input$year })
+  observeEvent(input$tabs, { current_context$tab  <- input$tabs })
+
+  # --- Per-session conversation state (never stored server-side) ---
+  session_history  <- reactiveVal(list())   # list of list(role=, content=)
+  pending_question <- reactiveVal(NULL)      # set while the agent is processing
+
+  # --- Provider / server-key discovery (GET /agent/providers) ---
+  providers_info <- reactive({
+    tryCatch({
+      resp <- httr::GET(paste0(API_BASE_URL, "/agent/providers"), httr::timeout(5))
+      if (httr::status_code(resp) != 200) return(NULL)
+      jsonlite::fromJSON(httr::content(resp, "text", encoding = "UTF-8"),
+                         simplifyVector = FALSE)
+    }, error = function(e) NULL)
+  })
+
+  output$server_key_configured <- reactive({
+    pi   <- providers_info()
+    prov <- if (!is.null(input$llm_provider)) input$llm_provider else "anthropic"
+    !is.null(pi) && isTRUE(pi[[prov]]$server_key_configured)
+  })
+  outputOptions(output, "server_key_configured", suspendWhenHidden = FALSE)
+
+  # If the selected provider has no server key but another one does, switch to it
+  # (so "set OPENAI_API_KEY on the server" shows "ready" without manual selection).
+  observeEvent(providers_info(), {
+    pi <- providers_info()
+    if (is.null(pi)) return()
+    prov <- if (!is.null(input$llm_provider)) input$llm_provider else "anthropic"
+    if (!isTRUE(pi[[prov]]$server_key_configured)) {
+      configured <- names(pi)[vapply(pi, function(x) isTRUE(x$server_key_configured), logical(1))]
+      if (length(configured) > 0) {
+        updateSelectInput(session, "llm_provider", selected = configured[[1]])
+      }
+    }
+  })
+
+  # --- Context summary shown on the AI tab ---
+  output$context_summary <- renderText({
+    yr <- if (is.null(current_context$year) || is.na(current_context$year)) "—" else current_context$year
+    paste0(
+      current_context$aoi, "\n",
+      current_context$sensor, " ", current_context$resolution, "m\n",
+      "Year: ", yr
+    )
+  })
+
+  # --- Conversation display: chat bubbles (user right, agent left) ---
+  output$conversation_display <- renderUI({
+    msgs <- session_history()
+    pend <- pending_question()
+    if (length(msgs) == 0 && is.null(pend)) {
+      return(div(class = "ai-chat",
+                 div(class = "ai-empty",
+                     "Ask a question about vegetation, fire, or land cover to get started.")))
+    }
+    bubbles <- lapply(msgs, function(m) {
+      role <- if (identical(m$role, "user")) "user" else "agent"
+      div(class = paste("ai-row", role),
+          div(class = paste("ai-bubble", role), m$content))
+    })
+    if (!is.null(pend)) {
+      bubbles <- c(bubbles, list(
+        div(class = "ai-row user",  div(class = "ai-bubble user", pend)),
+        div(class = "ai-row agent", div(class = "ai-bubble agent", "…thinking"))
+      ))
+    }
+    div(class = "ai-chat", bubbles)
+  })
+
+  # --- Send a question to /agent/chat (async so the spinner shows + app stays responsive) ---
+  observeEvent(input$send_question, {
+    q <- trimws(input$user_question)
+    if (nchar(q) == 0) return()
+
+    hist <- session_history()
+    app_context <- list(
+      tab        = current_context$tab,
+      aoi        = current_context$aoi,
+      sensor     = current_context$sensor,
+      resolution = current_context$resolution,
+      year       = current_context$year
+    )
+    body_list <- list(
+      question    = q,
+      history     = hist,
+      app_context = app_context,
+      provider    = if (!is.null(input$llm_provider)) input$llm_provider else "anthropic"
+    )
+    if (!is.null(input$user_api_key) && nzchar(input$user_api_key)) {
+      body_list$user_api_key <- input$user_api_key
+    }
+    body_json <- jsonlite::toJSON(body_list, auto_unbox = TRUE, null = "null")
+
+    pending_question(q)
+    shinyjs::disable("send_question")
+    updateTextAreaInput(session, "user_question", value = "")
+
+    fallback <- "Sorry, I couldn't process that. Please try again."
+
+    promises::finally(
+      promises::catch(
+        promises::then(
+          promises::future_promise({
+            resp <- httr::POST(
+              paste0(API_BASE_URL, "/agent/chat"),
+              body = body_json,
+              httr::content_type_json(),
+              httr::timeout(90)
+            )
+            list(status = httr::status_code(resp),
+                 text   = httr::content(resp, "text", encoding = "UTF-8"))
+          }),
+          onFulfilled = function(res) {
+            answer <- fallback
+            if (isTRUE(res$status == 200)) {
+              parsed <- tryCatch(jsonlite::fromJSON(res$text, simplifyVector = FALSE),
+                                 error = function(e) NULL)
+              if (!is.null(parsed) && !is.null(parsed$response) && nzchar(parsed$response)) {
+                answer <- parsed$response
+              }
+            }
+            session_history(c(session_history(), list(
+              list(role = "user",      content = q),
+              list(role = "assistant", content = answer)
+            )))
+          }
+        ),
+        onRejected = function(e) {
+          session_history(c(session_history(), list(
+            list(role = "user",      content = q),
+            list(role = "assistant", content = fallback)
+          )))
+        }
+      ),
+      onFinally = function() {
+        pending_question(NULL)
+        shinyjs::enable("send_question")
+      }
+    )
+  })
+
+  # --- Clear the conversation ---
+  observeEvent(input$clear_history, {
+    session_history(list())
+    pending_question(NULL)
+  })
+
 } # END SERVER

--- a/app/server.R
+++ b/app/server.R
@@ -211,15 +211,49 @@ server <- function(input, output, session) {
     req(input$country, input$resolution)
     country_name <- input$country
     resolution   <- input$resolution
+
+    # HOT PATH stub
+    # api_data <- try_api_call(...)
+    # if (!is.null(api_data)) return(api_data)
+
+    # WARM PATH: read pre-processed ndvi_monthly_by_class.parquet
+    pq_path <- get_parquet_path(country_name, resolution, "ndvi_monthly_by_class")
+    pq      <- try_read_parquet(pq_path)
+    if (!is.null(pq)) {
+      df <- pq[pq$aoi == country_name, c("year", "month", "land_cover", "mean_ndvi")]
+      if (nrow(df) > 0) {
+        # Only use parquet if it covers ALL years available from TIF files.
+        # The anomaly/productivity selectors are populated from TIF years; if a
+        # selected year is absent from the parquet the plot functions throw errors.
+        tif_years <- tryCatch(
+          .scenario_avail_years(data_dir, country_name, resolution),
+          error = function(e) integer(0)
+        )
+        pq_years <- unique(as.integer(df$year))
+        if (length(tif_years) > 0 && all(tif_years %in% pq_years)) {
+          df$year  <- as.integer(df$year)
+          df$month <- as.integer(df$month)
+          df <- .drop_empty_lc_classes(df)
+          message("=== scenario_ndvi_data: warm path (parquet), rows=", nrow(df))
+          attr(df, "data_source") <- "parquet"
+          return(df)
+        }
+        message("=== scenario_ndvi_data: parquet missing TIF years (",
+                paste(setdiff(tif_years, pq_years), collapse = ", "),
+                "), falling to cold path")
+      }
+    }
+
+    # COLD PATH (unchanged)
     land_use_src <- "S2_10m_LULC_2023"
     lulc_dir     <- file.path(data_dir, "LandUse", country_name, land_use_src)
-    message("=== scenario_ndvi_data: loading country=", country_name, " resolution=", resolution)
+    message("=== scenario_ndvi_data: cold path, country=", country_name, " resolution=", resolution)
     message("    lulc_dir exists: ", dir.exists(lulc_dir), " | path: ", lulc_dir)
     avail_years  <- .scenario_avail_years(data_dir, country_name, resolution)
     message("    avail_years: ", paste(avail_years, collapse = ", "))
     df <- .load_all_years(avail_years, country_name, resolution, data_dir, lulc_dir)
     message("    loaded rows: ", if (is.null(df)) "NULL" else nrow(df))
-    df
+    .drop_empty_lc_classes(df)
   })
 
   # ---------------------------------------------------------------------------------------------------
@@ -278,8 +312,10 @@ server <- function(input, output, session) {
     cmp_year    <- input$scenario_productivity_compare_year
 
     tryCatch({
+      scenario_df <- scenario_ndvi_data()
+      data_source_rv(if (!is.null(attr(scenario_df, "data_source"))) attr(scenario_df, "data_source") else "tif")
       res <- plot_productivity_comparison(
-        df           = scenario_ndvi_data(),
+        df           = scenario_df,
         selected_year = sel_year,
         compare_year  = if (nzchar(cmp_year)) cmp_year else NULL
       )
@@ -383,7 +419,9 @@ server <- function(input, output, session) {
     error_message_rv(NULL)
 
     tryCatch({
-      res <- plot_agricultural_monitoring(df = scenario_ndvi_data(), selected_class = input$agri_class)
+      scenario_df <- scenario_ndvi_data()
+      data_source_rv(if (!is.null(attr(scenario_df, "data_source"))) attr(scenario_df, "data_source") else "tif")
+      res <- plot_agricultural_monitoring(df = scenario_df, selected_class = input$agri_class)
       scenario_agri_result(res)
       scenario_agri_ready(TRUE)
       error_message_rv(NULL)
@@ -490,8 +528,10 @@ server <- function(input, output, session) {
     anom_year <- as.integer(input$scenario_anomaly_year)
 
     tryCatch({
+      scenario_df <- scenario_ndvi_data()
+      data_source_rv(if (!is.null(attr(scenario_df, "data_source"))) attr(scenario_df, "data_source") else "tif")
       res <- plot_anomaly_resilience(
-        df           = scenario_ndvi_data(),
+        df           = scenario_df,
         anomaly_year = anom_year
       )
       scenario_anomaly_result(res)
@@ -512,6 +552,35 @@ server <- function(input, output, session) {
   # Set Reactive values for AoI shape and error message
   aoi_shape_rv <- reactiveVal(NULL)
   error_message_rv <- reactiveVal(NULL)
+  data_source_rv <- reactiveVal("tif")
+
+  # Each chart area gets its own output ID so they can update independently.
+  # All read from the same data_source_rv() but must have unique HTML IDs.
+  .ds_label_ids <- c(
+    "ds_label_ndvi_ts", "ds_label_lc",
+    "ds_label_ba_seasonal", "ds_label_ba_daily",
+    "ds_label_productivity", "ds_label_anomaly", "ds_label_agri"
+  )
+  for (.lid in .ds_label_ids) {
+    local({
+      lid <- .lid
+      output[[lid]] <- renderText({
+        switch(data_source_rv(),
+          "parquet" = "Data: pre-processed (fast)",
+          "tif"     = "Data: computed from raw files",
+          "api"     = "Data: live API",
+          ""
+        )
+      })
+    })
+  }
+
+  # Reset label on every tab / sub-tab navigation.
+  observeEvent(
+    list(input$tabs, input$ndvisubtabs, input$basubtabs, input$scenariosubtabs),
+    { data_source_rv("tif") },
+    ignoreInit = TRUE
+  )
   
   # Update month selector based on the months available for the selected year.
   observeEvent(list(input$tabs, input$country, input$resolution, input$year), {
@@ -911,6 +980,7 @@ server <- function(input, output, session) {
       ndvi_ts_plot_obj(ndvi_result$plot)
       ndvi_ts_stats(ndvi_result$stats)
       ndvi_ts_view_rv(ts_view)
+      data_source_rv(if (!is.null(ndvi_result$data_source)) ndvi_result$data_source else "tif")
       error_message_rv(NULL) # Clear any previous error messages
       
     }, error = function(e) {
@@ -1421,6 +1491,37 @@ server <- function(input, output, session) {
     season_months  <- seq(input$ba_season_months[1], input$ba_season_months[2])
     res_m          <- as.numeric(gsub("[^0-9]", "", resolution))
     pixel_area_km2 <- (res_m / 1000)^2
+
+    # HOT PATH stub
+    # api_data <- try_api_call(...)
+
+    # WARM PATH: read pre-processed ba_daily.parquet
+    tryCatch({
+      pq_daily <- try_read_parquet(
+        get_parquet_path(country_name, resolution, "ba_daily", sensor_override = "burned_area")
+      )
+      if (!is.null(pq_daily)) {
+        pq_daily <- pq_daily[pq_daily$aoi == country_name & pq_daily$year %in% selected_years, ]
+        pq_daily$date  <- as.Date(pq_daily$date)
+        pq_daily$month <- as.integer(format(pq_daily$date, "%m"))
+        pq_daily <- pq_daily[pq_daily$month %in% season_months, ]
+        all_daily <- if (nrow(pq_daily) > 0) {
+          data.frame(
+            date = pq_daily$date,
+            km2  = pq_daily$burned_km2,
+            year = as.character(pq_daily$year),
+            stringsAsFactors = FALSE
+          )
+        } else NULL
+        ba_daily_plot_obj(plot_ba_daily_activity(all_daily, as.character(selected_years)))
+        error_message_rv(NULL)
+        data_source_rv("parquet")
+        message("=========== End of Daily Burn Activity Generation (parquet) =============")
+        return()
+      }
+    }, error = function(e) {
+      warning("BA daily warm path failed, falling through to cold path: ", e$message)
+    })
 
     data_path <- file.path(data_dir, "BurnedArea", country_name, paste0(resolution, "m_resolution"))
 

--- a/app/server.R
+++ b/app/server.R
@@ -414,6 +414,7 @@ server <- function(input, output, session) {
   observeEvent(input$agri_class, {
     scenario_agri_ready(FALSE)
     scenario_agri_result(NULL)
+    data_source_rv("none")
   }, ignoreInit = TRUE)
 
   output$agri_callout <- renderUI({
@@ -591,13 +592,14 @@ server <- function(input, output, session) {
   # Set Reactive values for AoI shape and error message
   aoi_shape_rv <- reactiveVal(NULL)
   error_message_rv <- reactiveVal(NULL)
-  data_source_rv <- reactiveVal("tif")
+  # "none" => no plot generated yet, so the label renders blank (switch default).
+  data_source_rv <- reactiveVal("none")
 
   # Each chart area gets its own output ID so they can update independently.
   # All read from the same data_source_rv() but must have unique HTML IDs.
   .ds_label_ids <- c(
-    "ds_label_ndvi_ts", "ds_label_lc",
-    "ds_label_ba_seasonal", "ds_label_ba_daily",
+    "ds_label_ndvi_ts", "ds_label_lc", "ds_label_ndvi_delta",
+    "ds_label_ba_seasonal", "ds_label_ba_daily", "ds_label_ba_map",
     "ds_label_productivity", "ds_label_anomaly", "ds_label_agri"
   )
   for (.lid in .ds_label_ids) {
@@ -614,10 +616,10 @@ server <- function(input, output, session) {
     })
   }
 
-  # Reset label on every tab / sub-tab navigation.
+  # Blank the label on every tab / sub-tab navigation (no plot shown yet).
   observeEvent(
     list(input$tabs, input$ndvisubtabs, input$basubtabs, input$scenariosubtabs),
-    { data_source_rv("tif") },
+    { data_source_rv("none") },
     ignoreInit = TRUE
   )
   
@@ -964,12 +966,14 @@ server <- function(input, output, session) {
     ndvi_ts_ready(FALSE)
     ndvi_ts_plot_obj(NULL)
     ndvi_ts_stats(NULL)
+    data_source_rv("none")
   }, ignoreInit = TRUE)
 
   observeEvent(input$ndvi_ts_view, {
     ndvi_ts_ready(FALSE)
     ndvi_ts_plot_obj(NULL)
     ndvi_ts_stats(NULL)
+    data_source_rv("none")
   }, ignoreInit = TRUE)
   
   # Observe the Generate Figure button
@@ -1284,6 +1288,7 @@ server <- function(input, output, session) {
       res <- compute_annual_ndvi_change(year_a, year_b, country_name, resolution, data_dir)
       ndvi_annual_result(res)
       ndvi_annual_ready(TRUE)
+      data_source_rv("tif")  # annual change is computed from raw TIF rasters
       error_message_rv(NULL)
     }, error = function(e) {
       ndvi_annual_ready(FALSE)
@@ -1432,6 +1437,7 @@ server <- function(input, output, session) {
       })
       
       ndvi_dm_ready(TRUE) # Mark UI as ready when both figures are rendered successfully (renderUI will now return the container)
+      data_source_rv("tif")  # delta maps are computed from raw TIF rasters
       error_message_rv(NULL) # Clear any previous error messages
       
     }, error = function(e) {
@@ -1794,6 +1800,7 @@ server <- function(input, output, session) {
 
       shinyjs::show("monthly_leaflet_wrap")
       ba_map_ready(TRUE)
+      data_source_rv("tif")  # static burned-area map is computed from raw TIF rasters
       error_message_rv(NULL)
     }, error = function(e) {
       ba_map_ready(FALSE)
@@ -1826,6 +1833,12 @@ server <- function(input, output, session) {
         }
       )
     })
+  })
+
+  # Fire Return Period uses the geometry hot path: reflect its source in the label.
+  observeEvent(frp_result(), {
+    r <- frp_result()
+    if (!is.null(r)) data_source_rv(if (!is.null(r$data_source)) r$data_source else "tif")
   })
 
   output$ba_frp_leaflet <- renderLeaflet({

--- a/app/src/agent_renderers.R
+++ b/app/src/agent_renderers.R
@@ -1,0 +1,241 @@
+# -----------------------------------------------------------------------------
+# AGENT RENDERERS (Phase 2B) — turn agent chart/table refs into Plotly + tables.
+#
+# Mode A: ref has $endpoint + $params (no $data) -> fetch via try_api_call(),
+#         reshape, hand to an existing plotting function.
+# Mode B: ref has $data (no $endpoint) -> render directly from inline data.
+# Leaflet maps + static images are handled in Step 3 (return empty plot here).
+# -----------------------------------------------------------------------------
+
+# ---- Chart dispatcher --------------------------------------------------------
+
+render_agent_chart <- function(chart) {
+  if (is.null(chart)) return(plotly::plotly_empty())
+
+  # Mode B: inline data
+  if (!is.null(chart$data) && is.null(chart$endpoint)) {
+    return(render_mode_b_chart(chart))
+  }
+
+  # Mode A: fetch + existing plotting function
+  switch(chart$type %||% "",
+    "timeseries_monthly"  = render_chart_timeseries_monthly(chart),
+    "timeseries_annual"   = render_chart_timeseries_annual(chart),
+    "landcover"           = render_chart_landcover(chart),
+    "burned_area_monthly" = render_chart_burned_area_monthly(chart),
+    "burned_area_daily"   = render_chart_burned_area_daily(chart),
+    "anomaly"             = render_chart_anomaly(chart),
+    "phenology"           = render_chart_phenology(chart),
+    plotly::layout(plotly::plotly_empty(),
+                   title = paste("Unknown chart type:", chart$type %||% "NA"))
+  )
+}
+
+# ---- Mode B generic chart ----------------------------------------------------
+
+render_mode_b_chart <- function(chart) {
+  df <- tryCatch(
+    as.data.frame(do.call(rbind, lapply(chart$data, as.data.frame))),
+    error = function(e) NULL
+  )
+  if (is.null(df) || nrow(df) == 0 || ncol(df) < 2) return(plotly::plotly_empty())
+
+  x_key <- chart$x_key %||% names(df)[1]
+  y_key <- chart$y_key %||% names(df)[2]
+
+  p <- if (identical(chart$type, "simple_line")) {
+    plotly::plot_ly(df, x = ~get(x_key), y = ~get(y_key),
+                    type = "scatter", mode = "lines+markers",
+                    line = list(color = "#2d6a4f"))
+  } else {
+    plotly::plot_ly(df, x = ~get(x_key), y = ~get(y_key),
+                    type = "bar", marker = list(color = "#2d6a4f"))
+  }
+
+  p <- plotly::layout(p,
+    title  = chart$title %||% "",
+    xaxis  = list(title = x_key),
+    yaxis  = list(title = y_key),
+    margin = list(t = 40)
+  )
+  plotly::config(p, displayModeBar = FALSE)
+}
+
+# ---- Mode A chart renderers --------------------------------------------------
+
+render_chart_timeseries_annual <- function(chart) {
+  df <- try_api_call(chart$endpoint, chart$params)
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+  plot_ndvi_annual(df)
+}
+
+render_chart_timeseries_monthly <- function(chart) {
+  df <- try_api_call(chart$endpoint, chart$params)
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+  # Reshape to the columns plot_ndvi_anomaly() expects (YearMonth, NDVI, Year, Month).
+  df$YearMonth <- as.Date(paste(df$year, sprintf("%02d", df$month), "01", sep = "-"))
+  df$NDVI      <- df$mean_ndvi
+  df$Year      <- as.character(df$year)
+  df$Month     <- sprintf("%02d", df$month)
+  latest <- max(df$year, na.rm = TRUE)
+  keep   <- c("YearMonth", "NDVI", "Year", "Month")
+  train  <- df[df$year <  latest, keep, drop = FALSE]
+  test   <- df[df$year == latest, keep, drop = FALSE]
+  if (nrow(train) == 0 || nrow(test) == 0) return(plotly::plotly_empty())
+  plot_ndvi_anomaly(train_ndvi_df = train, test_ndvi_df = test)
+}
+
+render_chart_landcover <- function(chart) {
+  df <- try_api_call(chart$endpoint, chart$params)
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+  year_param <- as.integer(chart$params$year %||% max(df$year, na.rm = TRUE))
+  df_year <- df[df$year == year_param, ]
+  summary_df <- df_year %>%
+    dplyr::group_by(land_cover) %>%
+    dplyr::summarise(mean_ndvi = mean(mean_ndvi, na.rm = TRUE), .groups = "drop") %>%
+    dplyr::arrange(dplyr::desc(mean_ndvi))
+  p <- plotly::plot_ly(summary_df, x = ~land_cover, y = ~mean_ndvi,
+                       type = "bar", marker = list(color = "#2d6a4f"))
+  plotly::layout(p,
+    title  = paste("NDVI by land cover class,", year_param),
+    xaxis  = list(title = ""),
+    yaxis  = list(title = "Mean NDVI"),
+    margin = list(t = 40)
+  )
+}
+
+render_chart_burned_area_monthly <- function(chart) {
+  df <- try_api_call(chart$endpoint, chart$params)
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+  latest <- max(df$year, na.rm = TRUE)
+  # Reshape to plot_ba_timeseries_plotly()'s contract (Month, mean_val, lower_ci, upper_ci).
+  tr <- unique(df[, c("month", "ba_mean", "ba_lower_ci", "ba_upper_ci")])
+  train_data <- data.frame(
+    Month    = sprintf("%02d", tr$month),
+    mean_val = tr$ba_mean,
+    lower_ci = pmax(tr$ba_lower_ci, 0),
+    upper_ci = tr$ba_upper_ci,
+    stringsAsFactors = FALSE
+  )
+  te <- df[df$year == latest, ]
+  if (nrow(te) == 0) return(plotly::plotly_empty())
+  test_data <- data.frame(
+    Month    = sprintf("%02d", te$month),
+    mean_val = te$burned_km2,
+    lower_ci = te$burned_km2,
+    upper_ci = te$burned_km2,
+    stringsAsFactors = FALSE
+  )
+  plot_ba_timeseries_plotly(train_data = train_data, test_data = test_data,
+                            test_year = latest)
+}
+
+render_chart_burned_area_daily <- function(chart) {
+  df <- try_api_call(chart$endpoint, chart$params)
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+  daily <- data.frame(
+    date = as.Date(df$date),
+    km2  = df$burned_km2,
+    year = as.character(df$year),
+    stringsAsFactors = FALSE
+  )
+  plot_ba_daily_activity(daily_data = daily,
+                         selected_years = unique(daily$year))
+}
+
+# /ndvi/by-landcover requires a `year`; the scenario plots need every year. Fetch
+# year-by-year over the sensor's range and bind. NULL/empty -> NULL.
+.agent_lc_fetch_all <- function(params) {
+  sensor     <- params$sensor %||% "modis"
+  start_year <- if (identical(sensor, "modis")) 2000L else 2019L
+  end_year   <- as.integer(format(Sys.Date(), "%Y"))
+  parts <- lapply(start_year:end_year, function(y) {
+    py <- params; py$year <- y
+    try_api_call("/api/v1/ndvi/by-landcover", py)
+  })
+  out <- do.call(rbind, Filter(Negate(is.null), parts))
+  if (is.null(out) || nrow(out) == 0) NULL else out
+}
+
+render_chart_anomaly <- function(chart) {
+  df <- .agent_lc_fetch_all(chart$params)
+  if (is.null(df)) return(plotly::plotly_empty())
+  anomaly_year <- as.integer(chart$params$year %||% max(df$year, na.rm = TRUE))
+  res <- tryCatch(plot_anomaly_resilience(df = df, anomaly_year = anomaly_year),
+                  error = function(e) NULL)
+  if (is.null(res) || is.null(res$heatmap)) return(plotly::plotly_empty())
+  res$heatmap
+}
+
+render_chart_phenology <- function(chart) {
+  df <- .agent_lc_fetch_all(chart$params)
+  if (is.null(df)) return(plotly::plotly_empty())
+  selected_class <- chart$params$land_cover %||% "Crops"
+  res <- tryCatch(plot_agricultural_monitoring(df = df, selected_class = selected_class),
+                  error = function(e) NULL)
+  if (is.null(res) || is.null(res$plot)) return(plotly::plotly_empty())
+  res$plot
+}
+
+# ---- Table dispatcher --------------------------------------------------------
+
+render_agent_table <- function(tbl) {
+  if (is.null(tbl)) return(data.frame())
+
+  # Mode B: inline data
+  if (!is.null(tbl$data) && is.null(tbl$endpoint)) {
+    df <- tryCatch(
+      as.data.frame(do.call(rbind, lapply(tbl$data, as.data.frame))),
+      error = function(e) data.frame()
+    )
+    if (!is.null(tbl$columns) && length(tbl$columns) > 0) {
+      cols <- intersect(unlist(tbl$columns), names(df))
+      if (length(cols) > 0) df <- df[, cols, drop = FALSE]
+    }
+    return(df)
+  }
+
+  # Mode A: fetch + per-type tidy
+  df <- try_api_call(tbl$endpoint, tbl$params)
+  if (is.null(df) || nrow(df) == 0) return(data.frame())
+
+  df <- switch(tbl$type %||% "",
+    "ndvi_annual" = {
+      df$mean_ndvi <- round(df$mean_ndvi, 4)
+      df[, c("year", "mean_ndvi"), drop = FALSE]
+    },
+    "ndvi_by_class" = {
+      year_param <- as.integer(tbl$params$year %||% max(df$year, na.rm = TRUE))
+      df %>%
+        dplyr::filter(year == year_param) %>%
+        dplyr::group_by(land_cover) %>%
+        dplyr::summarise(mean_ndvi = round(mean(mean_ndvi, na.rm = TRUE), 4),
+                         .groups = "drop") %>%
+        dplyr::arrange(dplyr::desc(mean_ndvi))
+    },
+    "burned_area" = {
+      df$burned_km2 <- round(df$burned_km2, 2)
+      keep <- intersect(c("year", "month", "burned_km2", "ba_mean"), names(df))
+      df[, keep, drop = FALSE]
+    },
+    "anomaly" = {
+      df$anomaly_value <- round(df$anomaly_value, 4)
+      df %>%
+        dplyr::arrange(anomaly_value) %>%
+        dplyr::select(year, month, land_cover, anomaly_value)
+    },
+    "phenology" = {
+      df %>%
+        dplyr::select(year, land_cover, green_up_month, peak_month,
+                      peak_ndvi, senescence_month) %>%
+        dplyr::mutate(peak_ndvi = round(peak_ndvi, 4))
+    },
+    df
+  )
+
+  if (!is.null(tbl$columns) && length(tbl$columns) > 0) {
+    cols <- intersect(unlist(tbl$columns), names(df))
+    if (length(cols) > 0) df <- df[, cols, drop = FALSE]
+  }
+  df
+}

--- a/app/src/agent_renderers.R
+++ b/app/src/agent_renderers.R
@@ -50,6 +50,14 @@ render_mode_b_chart <- function(chart) {
     df[[x_key]] <- factor(df[[x_key]], levels = month_levels)
   }
 
+  # Convert year-like integers to character to prevent decimal axis
+  # A value is year-like if it's a 4-digit integer between 1990 and 2100
+  if (is.numeric(df[[x_key]]) &&
+      all(df[[x_key]] == floor(df[[x_key]]), na.rm = TRUE) &&
+      all(df[[x_key]] >= 1990 & df[[x_key]] <= 2100, na.rm = TRUE)) {
+    df[[x_key]] <- as.character(df[[x_key]])
+  }
+
   p <- if (identical(chart$type, "simple_line")) {
     plotly::plot_ly(df, x = ~get(x_key), y = ~get(y_key),
                     type = "scatter", mode = "lines+markers",
@@ -182,13 +190,43 @@ render_chart_burned_area_daily <- function(chart) {
 }
 
 render_chart_anomaly <- function(chart) {
-  df <- .agent_lc_fetch_all(chart$params)
-  if (is.null(df)) return(plotly::plotly_empty())
+  params_lc <- modifyList(chart$params, list(format = "table"))
+  params_lc$year <- NULL
+  df <- try_api_call("/api/v1/ndvi/by-landcover", params_lc)
+
+  if (is.null(df)) {
+    sensor <- chart$params$sensor %||% "sentinel2"
+    years  <- if (sensor == "modis") 2000:2025 else 2019:2025
+    df_list <- lapply(years, function(y) {
+      try_api_call("/api/v1/ndvi/by-landcover",
+                   modifyList(chart$params, list(year = y, format = "table")))
+    })
+    df <- do.call(rbind, Filter(Negate(is.null), df_list))
+  }
+
+  if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+
+  # Ensure required columns exist with correct names and types
+  required <- c("year", "month", "land_cover", "mean_ndvi")
+  if (!all(required %in% names(df))) return(plotly::plotly_empty())
+
+  df$year       <- as.integer(df$year)
+  df$month      <- as.integer(df$month)
+  df$land_cover <- as.character(df$land_cover)
+  df$mean_ndvi  <- as.numeric(df$mean_ndvi)
+
+  df <- df[complete.cases(df[, required]), ]
+  if (nrow(df) == 0) return(plotly::plotly_empty())
+
   anomaly_year <- as.integer(chart$params$year %||% max(df$year, na.rm = TRUE))
-  res <- tryCatch(plot_anomaly_resilience(df = df, anomaly_year = anomaly_year),
-                  error = function(e) NULL)
-  if (is.null(res) || is.null(res$heatmap)) return(plotly::plotly_empty())
-  res$heatmap
+  if (!anomaly_year %in% df$year) anomaly_year <- max(df$year, na.rm = TRUE)
+
+  result <- tryCatch(
+    plot_anomaly_resilience(df = df, anomaly_year = anomaly_year),
+    error = function(e) NULL
+  )
+  if (is.null(result)) return(plotly::plotly_empty())
+  result$heatmap
 }
 
 render_chart_phenology <- function(chart) {
@@ -262,4 +300,108 @@ render_agent_table <- function(tbl) {
     if (length(cols) > 0) df <- df[, cols, drop = FALSE]
   }
   df
+}
+
+# ---- Leaflet map dispatcher (Step 3) -----------------------------------------
+
+render_agent_leaflet <- function(chart) {
+  switch(chart$type %||% "",
+    "delta_map"       = render_leaflet_delta_map(chart),
+    "frp_map"         = render_leaflet_frp(chart),
+    "burned_area_map" = render_leaflet_burned_area(chart),
+    leaflet::leaflet() %>% leaflet::addTiles()
+  )
+}
+
+# Spatial NDVI change between two years (reuses the Delta Map renderer).
+render_leaflet_delta_map <- function(chart) {
+  aoi    <- chart$params$aoi
+  sensor <- chart$params$sensor %||% "modis"
+  res    <- chart$params$resolution %||% 1000
+  result <- tryCatch(
+    compute_ndvi_delta_hot(aoi, sensor, res,
+                           chart$params$year_a, chart$params$year_b),
+    error = function(e) NULL
+  )
+  if (is.null(result)) {
+    return(leaflet::leaflet() %>% leaflet::addTiles() %>%
+             leaflet::addPopups(0, 0, "Delta map data unavailable."))
+  }
+  plot_annual_ndvi_leaflet(result)
+}
+
+# Fire return period (reuses build_ba_frp_leaflet; uses the global data_dir).
+render_leaflet_frp <- function(chart) {
+  aoi <- chart$params$aoi
+  res <- chart$params$resolution %||% 500
+  result <- tryCatch(
+    build_ba_frp_leaflet(data_dir = data_dir, country = aoi, resolution = res),
+    error = function(e) NULL
+  )
+  if (is.null(result)) {
+    return(leaflet::leaflet() %>% leaflet::addTiles() %>%
+             leaflet::addPopups(0, 0, "FRP data unavailable."))
+  }
+  result$map
+}
+
+# Annual burn-frequency map (API grid + AoI outline).
+render_leaflet_burned_area <- function(chart) {
+  aoi  <- chart$params$aoi
+  year <- chart$params$year %||% (as.integer(format(Sys.Date(), "%Y")) - 1)
+
+  grid_result <- tryCatch(
+    try_api_grid_call("/api/v1/burned-area/annual-grid", list(aoi = aoi, year = year)),
+    error = function(e) NULL
+  )
+  aoi_files <- list.files(file.path(data_dir, "AoI"),
+                          pattern = paste0("AoI.*", aoi, ".*\\.geojson$"))
+  aoi_shape <- if (length(aoi_files) > 0) tryCatch(
+    read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), aoi),
+    error = function(e) NULL) else NULL
+
+  if (is.null(grid_result) || is.null(aoi_shape)) {
+    return(leaflet::leaflet() %>% leaflet::addTiles() %>%
+             leaflet::addPopups(0, 0, "Burned area map data unavailable."))
+  }
+  build_ba_annual_leaflet(
+    ba_df            = parse_grid_response(grid_result),
+    aoi_shape        = aoi_shape,
+    year             = year,
+    total_burned_km2 = grid_result$metadata$total_burned_km2
+  )
+}
+
+# ---- Static comparison-image renderer (Step 3) -------------------------------
+# Builds a multi-year facet PNG (NDVI or burned area) from the hot builders.
+render_agent_image <- function(chart, output_id) {
+  aoi       <- chart$params$aoi
+  sensor    <- chart$params$sensor %||% "modis"
+  res       <- chart$params$resolution %||% 1000
+  month     <- as.integer(chart$params$month %||% 1)
+  years_vec <- as.integer(unlist(chart$params$years_vec))
+  map_year  <- if (length(years_vec)) max(years_vec) else
+                 as.integer(format(Sys.Date(), "%Y")) - 1
+  is_ba     <- grepl("burned-area", chart$endpoint %||% "", fixed = TRUE)
+
+  figures_dir <- file.path("www", "figures")
+  if (!dir.exists(figures_dir)) dir.create(figures_dir, recursive = TRUE)
+  filename <- paste0(output_id, ".png")
+
+  tryCatch({
+    if (is_ba) {
+      generate_ba_2Dmap_hot(country_name = aoi, map_year = map_year,
+                            map_month = month, figures_dir = figures_dir,
+                            figure_filename = filename, years_vec = years_vec)
+    } else {
+      generate_2Dmap_hot(country_name = aoi, sensor = sensor, resolution = res,
+                         map_year = map_year, map_month = month,
+                         figures_dir = figures_dir, figure_filename = filename,
+                         years_vec = years_vec)
+    }
+    list(src = file.path(figures_dir, filename), contentType = "image/png",
+         width = "100%", height = "auto", alt = chart$title %||% "Comparison map")
+  }, error = function(e) {
+    list(src = "", alt = paste("Image generation failed:", conditionMessage(e)))
+  })
 }

--- a/app/src/agent_renderers.R
+++ b/app/src/agent_renderers.R
@@ -43,6 +43,13 @@ render_mode_b_chart <- function(chart) {
   x_key <- chart$x_key %||% names(df)[1]
   y_key <- chart$y_key %||% names(df)[2]
 
+  # Reorder x-axis chronologically if values are month names
+  month_levels <- c("January","February","March","April","May","June",
+                    "July","August","September","October","November","December")
+  if (all(df[[x_key]] %in% month_levels)) {
+    df[[x_key]] <- factor(df[[x_key]], levels = month_levels)
+  }
+
   p <- if (identical(chart$type, "simple_line")) {
     plotly::plot_ly(df, x = ~get(x_key), y = ~get(y_key),
                     type = "scatter", mode = "lines+markers",
@@ -72,17 +79,29 @@ render_chart_timeseries_annual <- function(chart) {
 render_chart_timeseries_monthly <- function(chart) {
   df <- try_api_call(chart$endpoint, chart$params)
   if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
+
+  # Highlight the agent-specified year, else the most recent COMPLETE year
+  # (the max year is usually still in progress). Single-year data -> use it.
+  highlight_year <- as.integer(chart$params$year %||%
+                                 max(df$year[df$year < max(df$year)], na.rm = TRUE))
+  if (length(unique(df$year)) == 1) highlight_year <- unique(df$year)
+
   # Reshape to the columns plot_ndvi_anomaly() expects (YearMonth, NDVI, Year, Month).
   df$YearMonth <- as.Date(paste(df$year, sprintf("%02d", df$month), "01", sep = "-"))
   df$NDVI      <- df$mean_ndvi
   df$Year      <- as.character(df$year)
   df$Month     <- sprintf("%02d", df$month)
-  latest <- max(df$year, na.rm = TRUE)
-  keep   <- c("YearMonth", "NDVI", "Year", "Month")
-  train  <- df[df$year <  latest, keep, drop = FALSE]
-  test   <- df[df$year == latest, keep, drop = FALSE]
-  if (nrow(train) == 0 || nrow(test) == 0) return(plotly::plotly_empty())
-  plot_ndvi_anomaly(train_ndvi_df = train, test_ndvi_df = test)
+  keep  <- c("YearMonth", "NDVI", "Year", "Month")
+  train <- df[df$year != highlight_year, keep, drop = FALSE]
+  test  <- df[df$year == highlight_year, keep, drop = FALSE]
+  if (nrow(test) == 0) return(plotly::plotly_empty())
+
+  plot_ndvi_anomaly(train_ndvi_df = train, test_ndvi_df = test) %>%
+    plotly::layout(
+      legend = list(orientation = "h", x = 0.5, xanchor = "center",
+                    y = -0.32, yanchor = "top", font = list(size = 9)),
+      margin = list(t = 30, b = 130)
+    )
 }
 
 render_chart_landcover <- function(chart) {
@@ -107,8 +126,13 @@ render_chart_landcover <- function(chart) {
 render_chart_burned_area_monthly <- function(chart) {
   df <- try_api_call(chart$endpoint, chart$params)
   if (is.null(df) || nrow(df) == 0) return(plotly::plotly_empty())
-  latest <- max(df$year, na.rm = TRUE)
+
+  highlight_year <- as.integer(chart$params$year %||%
+                                 max(df$year[df$year < max(df$year)], na.rm = TRUE))
+  if (length(unique(df$year)) == 1) highlight_year <- unique(df$year)
+
   # Reshape to plot_ba_timeseries_plotly()'s contract (Month, mean_val, lower_ci, upper_ci).
+  # The baseline (ba_mean/CI) is per-calendar-month and year-independent.
   tr <- unique(df[, c("month", "ba_mean", "ba_lower_ci", "ba_upper_ci")])
   train_data <- data.frame(
     Month    = sprintf("%02d", tr$month),
@@ -117,7 +141,7 @@ render_chart_burned_area_monthly <- function(chart) {
     upper_ci = tr$ba_upper_ci,
     stringsAsFactors = FALSE
   )
-  te <- df[df$year == latest, ]
+  te <- df[df$year == highlight_year, ]
   if (nrow(te) == 0) return(plotly::plotly_empty())
   test_data <- data.frame(
     Month    = sprintf("%02d", te$month),
@@ -127,7 +151,7 @@ render_chart_burned_area_monthly <- function(chart) {
     stringsAsFactors = FALSE
   )
   plot_ba_timeseries_plotly(train_data = train_data, test_data = test_data,
-                            test_year = latest)
+                            test_year = highlight_year)
 }
 
 render_chart_burned_area_daily <- function(chart) {

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -16,20 +16,37 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
   # Sensor/resolution mapping shared by the hot-path API calls below.
   sr <- get_sensor_resolution(resolution)
 
-  # WARM PATH: annual view (no hot path — the /ndvi/timeseries endpoint returns
-  # monthly rows, not the ndvi_annual schema with n_months/is_complete).
+  # ANNUAL view: HOT (/ndvi/annual) -> WARM (ndvi_annual parquet) -> COLD (TIF).
   if (identical(view, "annual") && !use_lc_requested) {
-    pq_ann <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_annual"))
-    if (!is.null(pq_ann)) {
-      annual_df <- pq_ann[pq_ann$aoi == country_name,
-                          c("year", "mean_ndvi", "n_months", "is_complete")]
-      if (nrow(annual_df) > 0) {
-        annual_df$is_complete <- as.logical(annual_df$is_complete)
-        annual_plot  <- plot_ndvi_annual(annual_df, land_cover_class = NULL)
-        annual_stats <- compute_ndvi_annual_stats(annual_df)
-        annual_stats$view <- "annual"
-        return(list(plot = annual_plot, stats = annual_stats, view = "annual", data_source = "parquet"))
+    annual_df <- NULL
+    ds        <- NULL
+
+    # HOT PATH: dedicated annual time-series endpoint (year, mean_ndvi,
+    # n_months, is_complete). Falls through silently if unavailable.
+    api_ann <- if (!is.null(sr)) try_api_call(
+      endpoint = "/api/v1/ndvi/annual",
+      params   = list(aoi = country_name, sensor = sr$sensor, resolution = sr$resolution)
+    ) else NULL
+    if (!is.null(api_ann) &&
+        all(c("year", "mean_ndvi", "n_months", "is_complete") %in% names(api_ann))) {
+      annual_df <- api_ann[, c("year", "mean_ndvi", "n_months", "is_complete")]
+      ds        <- "api"
+    } else {
+      # WARM PATH: pre-processed ndvi_annual.parquet
+      pq_ann <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_annual"))
+      if (!is.null(pq_ann)) {
+        tmp <- pq_ann[pq_ann$aoi == country_name,
+                      c("year", "mean_ndvi", "n_months", "is_complete")]
+        if (nrow(tmp) > 0) { annual_df <- tmp; ds <- "parquet" }
       }
+    }
+
+    if (!is.null(annual_df) && nrow(annual_df) > 0) {
+      annual_df$is_complete <- as.logical(annual_df$is_complete)
+      annual_plot  <- plot_ndvi_annual(annual_df, land_cover_class = NULL)
+      annual_stats <- compute_ndvi_annual_stats(annual_df)
+      annual_stats$view <- "annual"
+      return(list(plot = annual_plot, stats = annual_stats, view = "annual", data_source = ds))
     }
   }
 

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -13,11 +13,11 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
 ) {
   use_lc_requested <- !is.null(land_cover_class) && nzchar(land_cover_class)
 
-  # HOT PATH stub
-  # api_data <- try_api_call(...)
-  # if (!is.null(api_data)) return(api_data)
+  # Sensor/resolution mapping shared by the hot-path API calls below.
+  sr <- get_sensor_resolution(resolution)
 
-  # WARM PATH: annual view
+  # WARM PATH: annual view (no hot path — the /ndvi/timeseries endpoint returns
+  # monthly rows, not the ndvi_annual schema with n_months/is_complete).
   if (identical(view, "annual") && !use_lc_requested) {
     pq_ann <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_annual"))
     if (!is.null(pq_ann)) {
@@ -35,10 +35,22 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
 
   # WARM PATH: monthly view (overall AoI only — no per-class data in ndvi_monthly)
   if (identical(view, "monthly") && !use_lc_requested) {
-    pq_path <- get_parquet_path(country_name, resolution, "ndvi_monthly")
-    pq      <- try_read_parquet(pq_path)
+    # HOT PATH: try the API first; the /timeseries table returns all years with
+    # the ndvi_monthly schema (year, month, mean_ndvi). Falls back silently.
+    ds <- "api"
+    pq <- if (!is.null(sr)) try_api_call(
+      endpoint = "/api/v1/ndvi/timeseries",
+      params   = list(aoi = country_name, sensor = sr$sensor, resolution = sr$resolution)
+    ) else NULL
+    if (is.null(pq)) {
+      ds      <- "parquet"
+      pq_path <- get_parquet_path(country_name, resolution, "ndvi_monthly")
+      pq      <- try_read_parquet(pq_path)
+    }
     if (!is.null(pq)) {
-      pq <- pq[pq$aoi == country_name, ]
+      # API responses carry no `aoi` column (already filtered server-side); the
+      # Parquet file does, so only filter when the column is present.
+      if ("aoi" %in% names(pq)) pq <- pq[pq$aoi == country_name, ]
       if (nrow(pq) > 0) {
         pq$YearMonth <- as.Date(paste(pq$year, sprintf("%02d", pq$month), "01", sep = "-"))
         pq$Year      <- as.character(pq$year)
@@ -61,7 +73,7 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
           if (isTRUE(return_plot)) {
             stats      <- compute_ndvi_explorer_stats(train_ndvi_df, test_ndvi_df)
             stats$view <- "monthly"
-            return(list(plot = ndvi_ts_plot, stats = stats, view = "monthly", data_source = "parquet"))
+            return(list(plot = ndvi_ts_plot, stats = stats, view = "monthly", data_source = ds))
           }
           return(invisible(NULL))
         }
@@ -172,17 +184,23 @@ generate_ba_timeseries <- function(country_name = NULL, resolution = NULL,
                                    figures_dir = NULL, data_dir = NULL,
                                    return_plot = FALSE, figure_filename = NULL
 ) {
-  # HOT PATH stub
-  # api_data <- try_api_call(...)
-  # if (!is.null(api_data)) return(api_data)
-
-  # WARM PATH: read pre-processed ba_monthly.parquet
+  # HOT PATH + WARM PATH: API first, then pre-processed ba_monthly.parquet.
+  # Both share the ba_monthly schema so the transform below is reused unchanged.
   if (isTRUE(return_plot)) {
-    pq_ba <- try_read_parquet(
-      get_parquet_path(country_name, resolution, "ba_monthly", sensor_override = "burned_area")
+    ds    <- "api"
+    pq_ba <- try_api_call(
+      endpoint = "/api/v1/burned-area/summary",
+      params   = list(aoi = country_name)
     )
+    if (is.null(pq_ba)) {
+      ds    <- "parquet"
+      pq_ba <- try_read_parquet(
+        get_parquet_path(country_name, resolution, "ba_monthly", sensor_override = "burned_area")
+      )
+    }
     if (!is.null(pq_ba)) {
-      pq_ba <- pq_ba[pq_ba$aoi == country_name, ]
+      # API summary has no `aoi` column (already filtered); Parquet does.
+      if ("aoi" %in% names(pq_ba)) pq_ba <- pq_ba[pq_ba$aoi == country_name, ]
       if (nrow(pq_ba) > 0) {
         train_ba <- unique(pq_ba[, c("month", "ba_mean", "ba_lower_ci", "ba_upper_ci")])
         train_ba <- data.frame(
@@ -201,10 +219,13 @@ generate_ba_timeseries <- function(country_name = NULL, resolution = NULL,
             upper_ci = test_raw$burned_km2,
             stringsAsFactors = FALSE
           )
-          return(plot_ba_timeseries_plotly(
-            train_data = train_ba,
-            test_data  = test_ba,
-            test_year  = end_year
+          return(list(
+            plot = plot_ba_timeseries_plotly(
+              train_data = train_ba,
+              test_data  = test_ba,
+              test_year  = end_year
+            ),
+            data_source = ds
           ))
         }
       }
@@ -285,10 +306,13 @@ generate_ba_timeseries <- function(country_name = NULL, resolution = NULL,
     test_raw        <- get_ba_summary_fast(test_files_df, data_path, aoi_proj)
     test_ba_summary <- get_summary_ba_df(ba_df = test_raw)
 
-    return(plot_ba_timeseries_plotly(
-      train_data = train_ba_summary,
-      test_data  = test_ba_summary,
-      test_year  = end_year
+    return(list(
+      plot = plot_ba_timeseries_plotly(
+        train_data = train_ba_summary,
+        test_data  = test_ba_summary,
+        test_year  = end_year
+      ),
+      data_source = "tif"
     ))
   }
 
@@ -572,17 +596,28 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                             "Flooded_vegetation", "Built_Area", "Bare_ground"
                                           )
 ) {
-  # HOT PATH: API call (not yet implemented)
-  # api_data <- try_api_call(...)
-  # if (!is.null(api_data)) return(api_data)
+  # HOT PATH (per-class NDVI only): the API supplies the ndvi_monthly_by_class
+  # table; the two baseline tables have no endpoint and are still read from
+  # Parquet. Tag "api" only when the per-class frame came from the API.
+  sr_lc <- get_sensor_resolution(resolution)
+  ds    <- "api"
+  pq_lc <- if (!is.null(sr_lc)) try_api_call(
+    endpoint = "/api/v1/ndvi/by-landcover",
+    params   = list(aoi = country_name, sensor = sr_lc$sensor,
+                    resolution = sr_lc$resolution, year = end_year)
+  ) else NULL
+  if (is.null(pq_lc)) {
+    ds    <- "parquet"
+    pq_lc <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_by_class"))
+  }
 
-  # WARM PATH: read pre-processed Parquet files if available
-  pq_lc     <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_by_class"))
+  # WARM PATH: read pre-processed baseline Parquet files if available
   pq_bl     <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_baselines"))
   pq_bl_cls <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_baselines_by_class"))
 
   if (!is.null(pq_lc) && !is.null(pq_bl) && !is.null(pq_bl_cls)) {
-    pq_lc     <- pq_lc    [pq_lc$aoi      == country_name, ]
+    # API per-class frame has no `aoi` column; the Parquet ones do.
+    if ("aoi" %in% names(pq_lc)) pq_lc <- pq_lc[pq_lc$aoi == country_name, ]
     pq_bl     <- pq_bl    [pq_bl$aoi      == country_name, ]
     pq_bl_cls <- pq_bl_cls[pq_bl_cls$aoi  == country_name, ]
     pq_lc$year  <- as.integer(pq_lc$year)
@@ -664,14 +699,14 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
             lulc_map_folder        = lulc_map_folder_path,
             aoi_sf                 = aoi_sf_pq
           )
-          if (isTRUE(return_plot)) return(list(plot = combo_pq$plot, bbox_by_stem = combo_pq$bbox_by_stem))
+          if (isTRUE(return_plot)) return(list(plot = combo_pq$plot, bbox_by_stem = combo_pq$bbox_by_stem, data_source = ds))
         } else {
           p_pq <- plot_ndvi_landcover_multiline(
             train_ndvi_summary_aoi = train_ndvi_summary_aoi_pq,
             land_cover_summaries   = land_cover_summaries_pq,
             name_ribbon            = name_ribbon_pq
           )
-          if (isTRUE(return_plot)) return(list(plot = p_pq, bbox_by_stem = NULL))
+          if (isTRUE(return_plot)) return(list(plot = p_pq, bbox_by_stem = NULL, data_source = ds))
         }
         return(invisible(NULL))
       }

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -572,8 +572,114 @@ generate_timeseries_landcover <- function(country_name = NULL, resolution = NULL
                                             "Flooded_vegetation", "Built_Area", "Bare_ground"
                                           )
 ) {
-  
+  # HOT PATH: API call (not yet implemented)
+  # api_data <- try_api_call(...)
+  # if (!is.null(api_data)) return(api_data)
+
+  # WARM PATH: read pre-processed Parquet files if available
+  pq_lc     <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_by_class"))
+  pq_bl     <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_baselines"))
+  pq_bl_cls <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_monthly_baselines_by_class"))
+
+  if (!is.null(pq_lc) && !is.null(pq_bl) && !is.null(pq_bl_cls)) {
+    pq_lc     <- pq_lc    [pq_lc$aoi      == country_name, ]
+    pq_bl     <- pq_bl    [pq_bl$aoi      == country_name, ]
+    pq_bl_cls <- pq_bl_cls[pq_bl_cls$aoi  == country_name, ]
+    pq_lc$year  <- as.integer(pq_lc$year)
+    pq_lc$month <- as.integer(pq_lc$month)
+
+    # Months present in the test year up to end_month — mirrors cold-path months_in_test
+    test_months_pq <- sort(unique(
+      pq_lc$month[pq_lc$year == as.integer(end_year) & pq_lc$month <= as.integer(end_month)]
+    ))
+
+    if (length(test_months_pq) > 0) {
+
+      # AoI-wide historical ribbon  →  train_ndvi_summary_aoi shape: Month, mean_val, lower_ci, upper_ci
+      bl_rows <- pq_bl[pq_bl$month %in% test_months_pq, ]
+      train_ndvi_summary_aoi_pq <- data.frame(
+        Month    = sprintf("%02d", as.integer(bl_rows$month)),
+        mean_val = bl_rows$climatology,
+        lower_ci = bl_rows$ts_lower,
+        upper_ci = bl_rows$ts_upper,
+        stringsAsFactors = FALSE
+      )
+
+      # Per-class summaries  →  land_cover_summaries shape: Month, mean_val, lower_ci, upper_ci, land_cover, period
+      lc_list_pq <- lapply(land_cover_classes, function(lc) {
+        # Test: current year, up to end_month
+        test_d <- pq_lc[pq_lc$land_cover == lc &
+                          pq_lc$year == as.integer(end_year) &
+                          pq_lc$month %in% test_months_pq, ]
+        if (nrow(test_d) == 0) return(NULL)
+        test_s <- data.frame(
+          Month    = sprintf("%02d", as.integer(test_d$month)),
+          mean_val = test_d$mean_ndvi,
+          lower_ci = NA_real_,
+          upper_ci = NA_real_,
+          stringsAsFactors = FALSE
+        )
+
+        # Train: pre-computed historical baseline per class
+        train_d <- pq_bl_cls[pq_bl_cls$land_cover == lc &
+                                pq_bl_cls$month %in% test_months_pq, ]
+        if (nrow(train_d) == 0) return(NULL)
+        train_s <- data.frame(
+          Month    = sprintf("%02d", as.integer(train_d$month)),
+          mean_val = train_d$lc_mean,
+          lower_ci = train_d$lc_lower_ci,
+          upper_ci = train_d$lc_upper_ci,
+          stringsAsFactors = FALSE
+        )
+
+        dplyr::bind_rows(
+          dplyr::mutate(train_s, land_cover = lc, period = "train"),
+          dplyr::mutate(test_s,  land_cover = lc, period = "test")
+        )
+      })
+      land_cover_summaries_pq <- dplyr::bind_rows(Filter(Negate(is.null), lc_list_pq))
+
+      if (nrow(land_cover_summaries_pq) > 0 && nrow(train_ndvi_summary_aoi_pq) > 0) {
+        cat("[LC Explorer] Warm path: reading Parquet\n")
+        Sys.setlocale("LC_TIME", "C")
+        name_ribbon_pq <- paste0(
+          "Historical range (until ",
+          format(as.Date(paste(end_year, "01", "01", sep = "-")), "%b %Y"),
+          ")"
+        )
+        use_map_pq <- !is.null(lulc_map_folder_path) && nzchar(lulc_map_folder_path) &&
+          dir.exists(lulc_map_folder_path)
+
+        if (isTRUE(use_map_pq)) {
+          aoi_path_pq <- file.path(data_dir, "AoI/")
+          aoi_sf_pq   <- get_aoi_vector(
+            aoi_files  = get_filenames(aoi_path_pq, "AoI", ".geojson", country_name),
+            aoi_path   = aoi_path_pq,
+            projection = "EPSG:4326"
+          )
+          combo_pq <- plot_ndvi_landcover_with_map(
+            train_ndvi_summary_aoi = train_ndvi_summary_aoi_pq,
+            land_cover_summaries   = land_cover_summaries_pq,
+            name_ribbon            = name_ribbon_pq,
+            lulc_map_folder        = lulc_map_folder_path,
+            aoi_sf                 = aoi_sf_pq
+          )
+          if (isTRUE(return_plot)) return(list(plot = combo_pq$plot, bbox_by_stem = combo_pq$bbox_by_stem))
+        } else {
+          p_pq <- plot_ndvi_landcover_multiline(
+            train_ndvi_summary_aoi = train_ndvi_summary_aoi_pq,
+            land_cover_summaries   = land_cover_summaries_pq,
+            name_ribbon            = name_ribbon_pq
+          )
+          if (isTRUE(return_plot)) return(list(plot = p_pq, bbox_by_stem = NULL))
+        }
+        return(invisible(NULL))
+      }
+    }
+  }
+  # COLD PATH (unchanged)
   data_type <- "NDVI"
+  cat("[LC Explorer] Cold path: computing from TIF\n")
   Sys.setlocale("LC_TIME", "C") # Otherwise creates language inconsistencies, at least locally
   
   data_path <- file.path(data_dir, paste0(data_type, "/",

--- a/app/src/generate_plots.R
+++ b/app/src/generate_plots.R
@@ -11,7 +11,65 @@ generate_timeseries <- function(country_name = NULL, resolution = NULL,
                                 land_cover_class = NULL,
                                 view = "monthly"
 ) {
+  use_lc_requested <- !is.null(land_cover_class) && nzchar(land_cover_class)
 
+  # HOT PATH stub
+  # api_data <- try_api_call(...)
+  # if (!is.null(api_data)) return(api_data)
+
+  # WARM PATH: annual view
+  if (identical(view, "annual") && !use_lc_requested) {
+    pq_ann <- try_read_parquet(get_parquet_path(country_name, resolution, "ndvi_annual"))
+    if (!is.null(pq_ann)) {
+      annual_df <- pq_ann[pq_ann$aoi == country_name,
+                          c("year", "mean_ndvi", "n_months", "is_complete")]
+      if (nrow(annual_df) > 0) {
+        annual_df$is_complete <- as.logical(annual_df$is_complete)
+        annual_plot  <- plot_ndvi_annual(annual_df, land_cover_class = NULL)
+        annual_stats <- compute_ndvi_annual_stats(annual_df)
+        annual_stats$view <- "annual"
+        return(list(plot = annual_plot, stats = annual_stats, view = "annual", data_source = "parquet"))
+      }
+    }
+  }
+
+  # WARM PATH: monthly view (overall AoI only — no per-class data in ndvi_monthly)
+  if (identical(view, "monthly") && !use_lc_requested) {
+    pq_path <- get_parquet_path(country_name, resolution, "ndvi_monthly")
+    pq      <- try_read_parquet(pq_path)
+    if (!is.null(pq)) {
+      pq <- pq[pq$aoi == country_name, ]
+      if (nrow(pq) > 0) {
+        pq$YearMonth <- as.Date(paste(pq$year, sprintf("%02d", pq$month), "01", sep = "-"))
+        pq$Year      <- as.character(pq$year)
+        pq$Month     <- sprintf("%02d", pq$month)
+        pq$NDVI      <- pq$mean_ndvi
+
+        end_date_pq   <- as.Date(paste(end_year, sprintf("%02d", end_month), "01", sep = "-"))
+        start_date_pq <- as.Date(paste(end_year, "01", "01", sep = "-"))
+        months_in_test_pq <- pq$month[pq$YearMonth >= start_date_pq & pq$YearMonth <= end_date_pq]
+
+        test_ndvi_df  <- pq[pq$YearMonth >= start_date_pq & pq$YearMonth <= end_date_pq,
+                            c("YearMonth", "NDVI", "Year", "Month")]
+        train_ndvi_df <- pq[pq$year < end_year & pq$month %in% months_in_test_pq,
+                            c("YearMonth", "NDVI", "Year", "Month")]
+
+        if (nrow(test_ndvi_df) > 0 && nrow(train_ndvi_df) > 0) {
+          ndvi_ts_plot <- plot_ndvi_anomaly(train_ndvi_df = train_ndvi_df,
+                                            test_ndvi_df  = test_ndvi_df,
+                                            land_cover_class = NULL)
+          if (isTRUE(return_plot)) {
+            stats      <- compute_ndvi_explorer_stats(train_ndvi_df, test_ndvi_df)
+            stats$view <- "monthly"
+            return(list(plot = ndvi_ts_plot, stats = stats, view = "monthly", data_source = "parquet"))
+          }
+          return(invisible(NULL))
+        }
+      }
+    }
+  }
+
+  # COLD PATH (unchanged)
   data_type  <- "NDVI"
   data_path  <- file.path(data_dir, paste0(data_type, "/", country_name, "/", resolution, "m_resolution/"))
   aoi_path   <- file.path(data_dir, "AoI")
@@ -114,9 +172,48 @@ generate_ba_timeseries <- function(country_name = NULL, resolution = NULL,
                                    figures_dir = NULL, data_dir = NULL,
                                    return_plot = FALSE, figure_filename = NULL
 ) {
-  
+  # HOT PATH stub
+  # api_data <- try_api_call(...)
+  # if (!is.null(api_data)) return(api_data)
+
+  # WARM PATH: read pre-processed ba_monthly.parquet
+  if (isTRUE(return_plot)) {
+    pq_ba <- try_read_parquet(
+      get_parquet_path(country_name, resolution, "ba_monthly", sensor_override = "burned_area")
+    )
+    if (!is.null(pq_ba)) {
+      pq_ba <- pq_ba[pq_ba$aoi == country_name, ]
+      if (nrow(pq_ba) > 0) {
+        train_ba <- unique(pq_ba[, c("month", "ba_mean", "ba_lower_ci", "ba_upper_ci")])
+        train_ba <- data.frame(
+          Month    = sprintf("%02d", train_ba$month),
+          mean_val = train_ba$ba_mean,
+          lower_ci = pmax(train_ba$ba_lower_ci, 0),
+          upper_ci = train_ba$ba_upper_ci,
+          stringsAsFactors = FALSE
+        )
+        test_raw <- pq_ba[pq_ba$year == end_year & pq_ba$month <= end_month, ]
+        if (nrow(test_raw) > 0) {
+          test_ba <- data.frame(
+            Month    = sprintf("%02d", test_raw$month),
+            mean_val = test_raw$burned_km2,
+            lower_ci = test_raw$burned_km2,
+            upper_ci = test_raw$burned_km2,
+            stringsAsFactors = FALSE
+          )
+          return(plot_ba_timeseries_plotly(
+            train_data = train_ba,
+            test_data  = test_ba,
+            test_year  = end_year
+          ))
+        }
+      }
+    }
+  }
+
+  # COLD PATH (unchanged)
   ### Set paths and define parameters
-  
+
   # figure path
   figure_path <- file.path(figures_dir, figure_filename)
   

--- a/app/src/scenario_analysis.R
+++ b/app/src/scenario_analysis.R
@@ -305,7 +305,7 @@ plot_productivity_comparison <- function(df, selected_year, compare_year = NULL)
     `Historical Min`    = round(stats_df$hist_min,    3),
     `Historical Max`    = round(stats_df$hist_max,    3),
     `Year-to-Year CV <span title="SD ÷ mean of each class’s annual NDVI across all available years — lower means more consistent year to year." style="cursor:help;color:#888;font-size:0.85em;">ⓘ</span>` = round(stats_df$cv, 3),
-    `Interpretation`    = stats_df$interpretation,
+    `Interpretation <span title="Each label is based on two things: (1) the land cover type, and (2) how much NDVI varies from year to year (CV). The same level of variability means something different depending on the land cover — for example, high variability in flooded areas reflects seasonal water levels (not vegetation damage), while high variability in crops or trees may signal stress. Built Area and Water always show a fixed label because NDVI is not a useful vegetation measure for those classes." style="cursor:help;color:#888;font-size:0.85em;">ⓘ</span>` = stats_df$interpretation,
     check.names = FALSE, stringsAsFactors = FALSE
   )
 
@@ -581,16 +581,17 @@ plot_agricultural_monitoring <- function(df, selected_class = "Crops") {
 
   years_available <- sort(unique(all_df$year))
 
-  # legendrank controls order: avg(1) → years(100+) → phenology(200+)
-  # Each year has its own unique legendgroup so it toggles individually.
-  # Section headers come from legendgrouptitle on the first trace of each section.
-  marker_meta <- list(
-    "Green-up"   = list(rank = 200L, group_title = "Phenology"),
-    "Peak"       = list(rank = 201L, group_title = NULL),
-    "Senescence" = list(rank = 202L, group_title = NULL)
+  # Legend layout: avg(rank 1) → phenology symbol keys(rank 200-202) → years(rank 100+).
+  # Each year's line AND its phenology markers share the same legendgroup ("yr_<year>"),
+  # so toggling a year in the legend shows/hides both the line and all its markers together.
+  # The three symbol-key traces (Green-up / Peak / Senescence) are empty reference entries
+  # that explain the marker shapes; they live in their own legendgroup so they stay visible.
+  symbol_keys <- list(
+    list(label = "Green-up",   color = "#43A047", base_sym = "triangle-up",   rank = 200L, group_title = "Phenology"),
+    list(label = "Peak",       color = "#1565C0", base_sym = "star",          rank = 201L, group_title = NULL),
+    list(label = "Senescence", color = "#E65100", base_sym = "triangle-down", rank = 202L, group_title = NULL)
   )
 
-  shown_in_legend <- character(0)
   p <- plotly::plot_ly()
 
   p <- plotly::add_lines(
@@ -603,19 +604,34 @@ plot_agricultural_monitoring <- function(df, selected_class = "Crops") {
     hovertemplate = paste0(selected_class, " avg: %{y:.3f}<extra></extra>")
   )
 
+  # Symbol-key traces — one NA point each, invisible on chart but shows in legend to explain marker shapes.
+  for (sk in symbol_keys) {
+    p <- plotly::add_markers(
+      p,
+      x = NA_real_, y = NA_real_,
+      name             = sk$label,
+      legendgroup      = paste0("sym_", sk$label),
+      legendgrouptitle = if (!is.null(sk$group_title)) list(text = sk$group_title) else NULL,
+      legendrank       = sk$rank,
+      showlegend       = TRUE,
+      marker           = list(symbol = sk$base_sym, color = sk$color, size = 10, opacity = 1),
+      hovertemplate    = "<extra></extra>"
+    )
+  }
+
   for (i in seq_along(years_available)) {
     yr    <- years_available[i]
     df_yr <- dplyr::arrange(all_df[all_df$year == yr, ], month)
     ph    <- pheno_df[pheno_df$year == yr, ]
+    yr_group <- paste0("yr_", yr)
 
-    # Each year gets unique legendgroup → individually toggleable.
-    # "Year" section header only on first year.
+    # Year line — the legend entry for this group.
     p <- plotly::add_lines(
       p,
       x = df_yr$month, y = df_yr$mean_ndvi,
       name             = as.character(yr),
       legendrank       = 100L + i,
-      legendgroup      = paste0("yr_", yr),
+      legendgroup      = yr_group,
       legendgrouptitle = if (i == 1L) list(text = "Year") else NULL,
       hovertemplate    = paste0(
         "<b>", yr, "</b><br>Month: %{x}<br>", selected_class, " NDVI: %{y:.3f}<extra></extra>"
@@ -660,27 +676,23 @@ plot_agricultural_monitoring <- function(df, selected_class = "Crops") {
       )
     )
 
+    # Markers share yr_group → toggling the year legend item hides/shows markers too.
     for (mk in marker_defs) {
       if (is.na(mk$month) || mk$conf == "Not detected") next
       ms <- .conf_marker_style(mk$conf, mk$base_sym)
       if (is.null(ms)) next
       ndvi_val <- df_yr$mean_ndvi[df_yr$month == mk$month]
       if (length(ndvi_val) == 0L) next
-      meta        <- marker_meta[[mk$label]]
-      first_shown <- !(mk$label %in% shown_in_legend)
       p <- plotly::add_markers(
         p, x = mk$month, y = ndvi_val[1L],
-        name             = mk$label,
-        legendgroup      = mk$label,
-        legendgrouptitle = if (first_shown) meta$group_title else NULL,
-        legendrank       = meta$rank,
-        showlegend       = first_shown,
-        marker           = list(size = ms$size, color = mk$color,
-                                symbol = ms$symbol, opacity = ms$opacity),
-        hovertemplate    = paste0("<b>", yr, " ", mk$label, "</b><br>",
-                                  gsub("\n", "<br>", mk$tip), "<extra></extra>")
+        name          = paste0(yr, " ", mk$label),
+        legendgroup   = yr_group,
+        showlegend    = FALSE,
+        marker        = list(size = ms$size, color = mk$color,
+                             symbol = ms$symbol, opacity = ms$opacity),
+        hovertemplate = paste0("<b>", yr, " ", mk$label, "</b><br>",
+                               gsub("\n", "<br>", mk$tip), "<extra></extra>")
       )
-      if (first_shown) shown_in_legend <- c(shown_in_legend, mk$label)
     }
   }
 

--- a/app/src/scenario_analysis.R
+++ b/app/src/scenario_analysis.R
@@ -51,9 +51,12 @@ load_ndvi_per_class <- function(year, region, resolution, data_dir, lulc_path) {
     lc_geojson_by_class[[lc]] <- candidates[[1]]
   }
 
+  # Probe the API once; skip per-class hot-path attempts if it is down.
+  lc_api_up <- api_is_available()
   vectors_by_class <- list()
   for (lc in land_cover_classes) {
-    v_sf <- sf::st_read(lc_geojson_by_class[[lc]], quiet = TRUE)
+    v_sf <- read_landcover_geometry(lc_geojson_by_class[[lc]], region, lc,
+                                    api_available = lc_api_up)
     v_sf <- sf::st_transform(v_sf, crs = 4326)
     vectors_by_class[[lc]] <- terra::vect(v_sf)
   }

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -201,6 +201,82 @@ read_landcover_geometry <- function(file, aoi, land_cover_class,
   sf::st_read(file, quiet = TRUE)
 }
 
+#' Fetch a per-pixel grid response from the API (annual-grid, monthly-grid,
+#' monthly-anomaly-grid, burned-area grids). Unlike try_api_call() this returns
+#' the FULL parsed response (with $grid and $metadata) rather than $data, and it
+#' does NOT send format=table. NULL if the API is unavailable / errors / returns
+#' no grid (error responses have status "error" and no $grid).
+#'
+#' @param endpoint Character. e.g. "/api/v1/ndvi/annual-grid"
+#' @param params Named list. Query parameters.
+#' @param timeout_secs Numeric.
+#' @return Parsed response list (with $grid, $metadata) or NULL.
+try_api_grid_call <- function(endpoint, params,
+                              timeout_secs = API_TIMEOUT_SECS) {
+  tryCatch({
+    url <- paste0(API_BASE_URL, endpoint)
+    response <- httr::GET(url, query = params, httr::timeout(timeout_secs))
+    if (httr::status_code(response) != 200) return(NULL)
+    content <- httr::content(response, "text", encoding = "UTF-8")
+    parsed <- jsonlite::fromJSON(content, flatten = FALSE)
+    if (is.null(parsed$grid)) return(NULL)
+    parsed
+  }, error = function(e) NULL)
+}
+
+#' Parse a compact 2D grid response into a flat data frame with lat, lon, value.
+#'
+#' Robust to jsonlite's simplification: `grid$values` may arrive as a numeric
+#' matrix (when rectangular) or a list of row-lists (when nulls break
+#' simplification). Both are normalised to an [n_lat x n_lon] matrix, then
+#' expanded; masked (null/NA) pixels are dropped.
+#'
+#' @param response Parsed grid response (from try_api_grid_call()).
+#' @return data.frame with columns lat, lon, value (non-NA pixels only).
+parse_grid_response <- function(response) {
+  grid <- response$grid
+  lats <- as.numeric(grid$lats)
+  lons <- as.numeric(grid$lons)
+  vals <- grid$values
+
+  to_num_row <- function(r) {
+    r[vapply(r, is.null, logical(1))] <- NA
+    as.numeric(unlist(r))
+  }
+  if (is.matrix(vals)) {
+    m <- matrix(as.numeric(vals), nrow = nrow(vals), ncol = ncol(vals))
+  } else {
+    m <- do.call(rbind, lapply(vals, to_num_row))
+  }
+  # m[i, j] = value at lat i, lon j
+  if (is.null(m) || length(m) == 0L) {
+    return(data.frame(lat = numeric(0), lon = numeric(0), value = numeric(0)))
+  }
+
+  idx <- expand.grid(lat_idx = seq_along(lats), lon_idx = seq_along(lons))
+  df <- data.frame(
+    lat   = lats[idx$lat_idx],
+    lon   = lons[idx$lon_idx],
+    value = m[cbind(idx$lat_idx, idx$lon_idx)]
+  )
+  df[!is.na(df$value), , drop = FALSE]
+}
+
+#' Total AoI area (km^2) from the API geometry endpoint (its top-level
+#' `area_km2`). NULL if the API is unavailable. Used to turn burned-area km²
+#' into a percentage-of-study-area for the BA facet labels.
+get_aoi_area_km2 <- function(aoi, timeout_secs = API_TIMEOUT_SECS) {
+  tryCatch({
+    resp <- httr::GET(paste0(API_BASE_URL, "/api/v1/geometry/aoi"),
+                      query = list(aoi = aoi), httr::timeout(timeout_secs))
+    if (httr::status_code(resp) != 200) return(NULL)
+    parsed <- jsonlite::fromJSON(httr::content(resp, "text", encoding = "UTF-8"),
+                                 flatten = FALSE)
+    a <- suppressWarnings(as.numeric(parsed$area_km2))
+    if (length(a) == 0L || is.na(a) || a <= 0) NULL else a
+  }, error = function(e) NULL)
+}
+
 # Remove land_cover classes that have NO valid (non-NA) mean_ndvi across all
 # rows.  At coarse resolutions tiny classes (e.g. Flooded_vegetation < 0.1 km²)
 # contain no raster pixels, producing all-NA mean_ndvi.  plot_anomaly_resilience

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -118,15 +118,20 @@ api_is_available <- function() {
 
 #' Try to fetch geometry from the FastAPI hot path
 #'
-#' Added for Phase 1 but not yet wired into the geometry load sites — those
-#' still read GeoJSON files directly. `sf::st_read()` can parse a GeoJSON string
-#' returned by the API directly, not just a file path.
+#' `sf::st_read()` can parse a GeoJSON string returned by the API directly, not
+#' just a file path. When `return_metadata = TRUE` the FeatureCollection's
+#' top-level `metadata` object (e.g. the FRP year range) is returned alongside
+#' the parsed geometry.
 #'
 #' @param endpoint Character. e.g. "/api/v1/geometry/landcover"
 #' @param params Named list. Query parameters.
+#' @param return_metadata Logical. If TRUE, return a list with `geometry` (sf)
+#'        and `metadata` (parsed FeatureCollection metadata). Default FALSE.
 #' @param timeout_secs Numeric.
-#' @return sf object if successful, NULL if API unavailable.
+#' @return sf object (or list with geometry + metadata) on success; NULL if the
+#'         API is unavailable.
 try_api_geometry <- function(endpoint, params,
+                             return_metadata = FALSE,
                              timeout_secs = API_TIMEOUT_SECS) {
   tryCatch({
     url <- paste0(API_BASE_URL, endpoint)
@@ -136,8 +141,19 @@ try_api_geometry <- function(endpoint, params,
       httr::timeout(timeout_secs)
     )
     if (httr::status_code(response) != 200) return(NULL)
-    geojson_text <- httr::content(response, "text", encoding = "UTF-8")
-    sf::st_read(geojson_text, quiet = TRUE)
+
+    content_text <- httr::content(response, "text", encoding = "UTF-8")
+    sf_obj <- sf::st_read(content_text, quiet = TRUE)
+
+    if (return_metadata) {
+      parsed <- jsonlite::fromJSON(content_text, flatten = FALSE)
+      list(
+        geometry = sf_obj,
+        metadata = parsed$metadata
+      )
+    } else {
+      sf_obj
+    }
   }, error = function(e) NULL)
 }
 

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -68,6 +68,79 @@ try_read_parquet <- function(path) {
   )
 }
 
+#' Try to fetch data from the FastAPI hot path
+#'
+#' @param endpoint Character. API endpoint path, e.g. "/api/v1/ndvi/timeseries"
+#' @param params Named list. Query parameters.
+#' @param timeout_secs Numeric. Seconds before giving up and falling through.
+#' @return data.frame if successful, NULL if API unavailable or returns error.
+try_api_call <- function(endpoint, params, timeout_secs = API_TIMEOUT_SECS) {
+  # Add format=table to all data requests so response matches Parquet schema
+  params$format <- "table"
+
+  tryCatch({
+    url <- paste0(API_BASE_URL, endpoint)
+    response <- httr::GET(
+      url,
+      query = params,
+      httr::timeout(timeout_secs)
+    )
+
+    if (httr::status_code(response) != 200) return(NULL)
+
+    content <- httr::content(response, "text", encoding = "UTF-8")
+    parsed <- jsonlite::fromJSON(content, flatten = FALSE)
+
+    if (is.null(parsed$data) || length(parsed$data) == 0) return(NULL)
+
+    as.data.frame(parsed$data)
+
+  }, error = function(e) {
+    # Silent fallback — do not show error to user
+    # Common causes: API not running, network timeout, invalid response
+    NULL
+  })
+}
+
+#' Check if the API is reachable
+#'
+#' @return TRUE if /health responds within timeout, FALSE otherwise
+api_is_available <- function() {
+  result <- tryCatch({
+    response <- httr::GET(
+      paste0(API_BASE_URL, "/api/v1/health"),
+      httr::timeout(1)  # shorter timeout for health check
+    )
+    httr::status_code(response) == 200
+  }, error = function(e) FALSE)
+  result
+}
+
+#' Try to fetch geometry from the FastAPI hot path
+#'
+#' Added for Phase 1 but not yet wired into the geometry load sites — those
+#' still read GeoJSON files directly. `sf::st_read()` can parse a GeoJSON string
+#' returned by the API directly, not just a file path.
+#'
+#' @param endpoint Character. e.g. "/api/v1/geometry/landcover"
+#' @param params Named list. Query parameters.
+#' @param timeout_secs Numeric.
+#' @return sf object if successful, NULL if API unavailable.
+try_api_geometry <- function(endpoint, params,
+                             timeout_secs = API_TIMEOUT_SECS) {
+  tryCatch({
+    url <- paste0(API_BASE_URL, endpoint)
+    response <- httr::GET(
+      url,
+      query = params,
+      httr::timeout(timeout_secs)
+    )
+    if (httr::status_code(response) != 200) return(NULL)
+    geojson_text <- httr::content(response, "text", encoding = "UTF-8")
+    sf::st_read(geojson_text, quiet = TRUE)
+  }, error = function(e) NULL)
+}
+
 # Remove land_cover classes that have NO valid (non-NA) mean_ndvi across all
 # rows.  At coarse resolutions tiny classes (e.g. Flooded_vegetation < 0.1 km²)
 # contain no raster pixels, producing all-NA mean_ndvi.  plot_anomaly_resilience

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -141,6 +141,50 @@ try_api_geometry <- function(endpoint, params,
   }, error = function(e) NULL)
 }
 
+#' Load an AoI boundary polygon: API hot path, GeoJSON file fallback.
+#'
+#' The API serves geometry in EPSG:4326; callers still re-project afterwards,
+#' which is a harmless no-op on hot-path data. Falls back silently to the file.
+#'
+#' @param file Character. Fallback GeoJSON path (already resolved by the caller).
+#' @param aoi  Character. AoI name, e.g. "Zambia_Mponda".
+#' @return sf object (API or file). Errors only if BOTH the API and file fail.
+read_aoi_geometry <- function(file, aoi) {
+  if (!is.null(aoi) && nzchar(aoi)) {
+    sf_obj <- try_api_geometry("/api/v1/geometry/aoi", list(aoi = aoi))
+    if (!is.null(sf_obj)) return(sf_obj)
+  }
+  sf::st_read(file, quiet = TRUE)
+}
+
+#' Load land-cover class polygons: API hot path, GeoJSON file fallback.
+#'
+#' Uses simplified geometry from the API (≈84% smaller, ~0.3% area drift,
+#' invisible to users). The hot path only runs when the AoI and class are known;
+#' otherwise it reads the file directly.
+#'
+#' @param file Character. Fallback per-class GeoJSON path.
+#' @param aoi  Character. AoI name, e.g. "Zambia_Mponda".
+#' @param land_cover_class Character. e.g. "Crops" (NA / "" skips the hot path).
+#' @param api_available Logical. When FALSE, skip the API entirely and read the
+#'        file. Callers looping over many classes should pass a single
+#'        `api_is_available()` result so a down API costs one probe, not one
+#'        2-second timeout per class.
+#' @return sf object (API or file).
+read_landcover_geometry <- function(file, aoi, land_cover_class,
+                                    api_available = TRUE) {
+  if (isTRUE(api_available) && !is.null(aoi) && nzchar(aoi) &&
+      !is.null(land_cover_class) && !is.na(land_cover_class) &&
+      nzchar(land_cover_class)) {
+    sf_obj <- try_api_geometry(
+      "/api/v1/geometry/landcover",
+      list(aoi = aoi, land_cover_class = land_cover_class, simplified = TRUE)
+    )
+    if (!is.null(sf_obj)) return(sf_obj)
+  }
+  sf::st_read(file, quiet = TRUE)
+}
+
 # Remove land_cover classes that have NO valid (non-NA) mean_ndvi across all
 # rows.  At coarse resolutions tiny classes (e.g. Flooded_vegetation < 0.1 km²)
 # contain no raster pixels, producing all-NA mean_ndvi.  plot_anomaly_resilience

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -3,6 +3,9 @@
 # UTILITY FUNCTIONS
 # -----------------------------------------------------------------------------
 
+# Null-coalescing operator: a if non-NULL, else b.
+`%||%` <- function(a, b) if (!is.null(a)) a else b
+
 #' Map app resolution key to pipeline sensor and resolution number
 #'
 #' The app uses resolution keys like "Sentinel_1000", "MODIS_1000", "100" etc.

--- a/app/src/utilities.R
+++ b/app/src/utilities.R
@@ -3,6 +3,82 @@
 # UTILITY FUNCTIONS
 # -----------------------------------------------------------------------------
 
+#' Map app resolution key to pipeline sensor and resolution number
+#'
+#' The app uses resolution keys like "Sentinel_1000", "MODIS_1000", "100" etc.
+#' The pipeline stores Parquet files by sensor name and numeric resolution.
+#' This function bridges the two naming conventions.
+#'
+#' @param resolution_key Character. One of the values from resolutionchoices_rv.
+#' @return Named list with 'sensor' (character) and 'resolution' (integer),
+#'         or NULL if the key is not recognised.
+get_sensor_resolution <- function(resolution_key) {
+  mapping <- list(
+    "100"          = list(sensor = "sentinel2", resolution = 100L),
+    "Sentinel_1000"= list(sensor = "sentinel2", resolution = 1000L),
+    "250"          = list(sensor = "modis",     resolution = 250L),
+    "500"          = list(sensor = "modis",     resolution = 500L),
+    "MODIS_1000"   = list(sensor = "modis",     resolution = 1000L)
+  )
+  mapping[[resolution_key]]
+}
+
+#' Build the full path to a pre-processed Parquet file
+#'
+#' @param aoi Character. AoI name matching folder name, e.g. "Zambia_Mponda".
+#' @param resolution_key Character. App resolution key, e.g. "Sentinel_1000".
+#' @param table_name Character. Parquet table name without extension,
+#'        e.g. "ndvi_monthly", "ndvi_monthly_by_class", "ba_monthly".
+#' @param sensor_override Character or NULL. If not NULL, use this sensor
+#'        instead of deriving from resolution_key. Used for burned_area.
+#' @return Full file path as character, or NULL if resolution_key not recognised.
+get_parquet_path <- function(aoi, resolution_key, table_name,
+                             sensor_override = NULL) {
+  if (!is.null(sensor_override)) {
+    sensor <- sensor_override
+    resolution <- as.integer(sub("[^0-9]", "", resolution_key))
+  } else {
+    sr <- get_sensor_resolution(resolution_key)
+    if (is.null(sr)) return(NULL)
+    sensor <- sr$sensor
+    resolution <- sr$resolution
+  }
+
+  file.path(
+    "www/data/processed",
+    aoi,
+    sensor,
+    paste0(resolution, "m"),
+    paste0(table_name, ".parquet")
+  )
+}
+
+#' Try to read a Parquet file, return NULL if it doesn't exist
+#'
+#' @param path Character. Full path from get_parquet_path().
+#' @return data.frame from arrow::read_parquet(), or NULL if file not found.
+try_read_parquet <- function(path) {
+  if (is.null(path) || !file.exists(path)) return(NULL)
+  tryCatch(
+    arrow::read_parquet(path),
+    error = function(e) {
+      warning(paste("Failed to read Parquet:", path, "-", e$message))
+      NULL
+    }
+  )
+}
+
+# Remove land_cover classes that have NO valid (non-NA) mean_ndvi across all
+# rows.  At coarse resolutions tiny classes (e.g. Flooded_vegetation < 0.1 km²)
+# contain no raster pixels, producing all-NA mean_ndvi.  plot_anomaly_resilience
+# crashes when which.min() receives an all-NA vector, so we drop these classes
+# before the data reaches any plot function.
+.drop_empty_lc_classes <- function(df) {
+  if (is.null(df) || nrow(df) == 0) return(df)
+  valid_lc <- unique(df$land_cover[!is.na(df$mean_ndvi)])
+  df[df$land_cover %in% valid_lc, , drop = FALSE]
+}
+
 # get system language from locale (Windows)
 get_sys_language <- function(OS) {
   default_locale <- Sys.getlocale("LC_CTYPE")

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -312,6 +312,12 @@ lc_simplify_wgs84_for_plot <- function(x, dTolerance_m = 75, dTolerance_deg = 0.
     sf::st_simplify(g, dTolerance = dtol, preserveTopology = TRUE),
     error = function(e) g
   )
+  # Simplifying an already-simplified or very small polygon can collapse it into
+  # an empty geometry or a GEOMETRYCOLLECTION, which plotly::add_sf cannot draw
+  # ("not implemented for objects of class sfc_GEOMETRYCOLLECTION"). Keep the
+  # original geometry for any feature that degenerated this way.
+  bad <- sf::st_is_empty(sg) | sf::st_geometry_type(sg) == "GEOMETRYCOLLECTION"
+  if (any(bad)) sg[bad] <- g[bad]
   sf::st_set_geometry(x, sg)
 }
 

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -388,6 +388,11 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   ord <- order(landuse_types)
   geojson_files <- geojson_files[ord]
   landuse_types <- landuse_types[ord]
+  # AoI name for the geometry hot path; folder is .../LandUse/{aoi}/S2_10m_LULC_2023.
+  # Probe once so a down API costs a single 1s health check, not one 2s timeout
+  # per class across the loops below.
+  aoi_name <- basename(dirname(folder_path))
+  lc_api_up <- api_is_available()
   pal_named <- land_cover_class_colors()
   bbox_by_stem <- vector("list", length(landuse_types))
   names(bbox_by_stem) <- landuse_types
@@ -421,14 +426,19 @@ plot_lulc_map_plotly_from_folder <- function(folder_path, aoi_sf = NULL) {
   }
   if (is.na(total_study_area_ha) || total_study_area_ha <= 0) {
     total_study_area_ha <- sum(vapply(geojson_files, function(fp) {
-      g <- sf::st_read(fp, quiet = TRUE)
+      g <- read_landcover_geometry(
+        fp, aoi_name, geojson_stem_to_class_key(tools::file_path_sans_ext(basename(fp))),
+        api_available = lc_api_up
+      )
       g <- sf::st_transform(g, crs = 4326)
       sum(as.numeric(sf::st_area(g)), na.rm = TRUE) / 10000
     }, numeric(1)), na.rm = TRUE)
   }
   for (i in seq_along(geojson_files)) {
     stem <- landuse_types[i]
-    geojson_data <- sf::st_read(geojson_files[i], quiet = TRUE)
+    geojson_data <- read_landcover_geometry(geojson_files[i], aoi_name,
+                                            geojson_stem_to_class_key(stem),
+                                            api_available = lc_api_up)
     geojson_data <- lc_simplify_wgs84_for_plot(sf::st_transform(geojson_data, crs = 4326))
     bbox_by_stem[[stem]] <- sf::st_bbox(geojson_data)
     lab_short <- geojson_stem_to_class_key(stem)
@@ -1832,10 +1842,18 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
   geojson_files <- geojson_files[ord]
   landuse_types <- landuse_types[ord]
   
+  # AoI name for the geometry hot path; folder is .../LandUse/{aoi}/S2_10m_LULC_2023.
+  # Probe the API once (avoids a per-class 2s timeout when it is down).
+  aoi_name <- basename(dirname(folder_path))
+  lc_api_up <- api_is_available()
+
   # Pre-calculate total study area (Improvement 7: for percentage in tooltip)
   total_study_area_ha <- 0
   for (file in geojson_files) {
-    gj <- sf::st_read(file, quiet = TRUE)
+    gj <- read_landcover_geometry(
+      file, aoi_name, geojson_stem_to_class_key(tools::file_path_sans_ext(basename(file))),
+      api_available = lc_api_up
+    )
     gj <- sf::st_transform(gj, crs = 4326)
     total_study_area_ha <- total_study_area_ha + sum(as.numeric(sf::st_area(gj)) / 10000)
   }
@@ -1862,9 +1880,11 @@ plot_geojsons_from_a_folder <- function(folder_path, save_path = NULL, filename 
     file <- geojson_files[i]
     landuse_type <- landuse_types[i]
     
-    # Read the GeoJSON file
-    geojson_data <- sf::st_read(file, quiet = TRUE)
-    
+    # Read the GeoJSON file (API hot path, file fallback)
+    geojson_data <- read_landcover_geometry(file, aoi_name,
+                                            geojson_stem_to_class_key(landuse_type),
+                                            api_available = lc_api_up)
+
     # Transform the GeoJSON data to WGS 84 (EPSG:4326)
     geojson_data <- sf::st_transform(geojson_data, crs = 4326)
     bbox_by_stem[[landuse_type]] <- sf::st_bbox(geojson_data)
@@ -2039,9 +2059,9 @@ plot_ba_geojson_from_a_folder <- function(input_file_path, data_dir = data_dir, 
   if (length(aoi_files) == 0) {
     stop("No Area of Interest file found for the selected country.")
   }
-  aoi_shape <- sf::st_read(file.path(data_dir, "AoI", aoi_files[[1]]))
+  aoi_shape <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), country)
   aoi_shape <- sf::st_transform(aoi_shape, crs = 4326)
-  
+
   # Create a leaflet map with the specified basemap
   map <- leaflet() %>%
     addProviderTiles(providers[[basemap]]) %>%
@@ -2109,7 +2129,7 @@ build_ba_monthly_leaflet <- function(geojson_path = NULL, data_dir = NULL,
   aoi_files <- list.files(file.path(data_dir, "AoI"),
                           pattern = paste0("AoI.*", country, ".*\\.geojson$"))
   if (length(aoi_files) == 0) stop("No Area of Interest file found for the selected country.")
-  aoi_shape  <- sf::st_read(file.path(data_dir, "AoI", aoi_files[[1]]), quiet = TRUE)
+  aoi_shape  <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), country)
   aoi_shape  <- sf::st_transform(aoi_shape, crs = 4326)
   aoi_bounds <- sf::st_bbox(aoi_shape)
 
@@ -2182,7 +2202,7 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
   aoi_files <- list.files(file.path(data_dir, "AoI"),
                           pattern = paste0("AoI.*", country, ".*\\.geojson$"))
   if (length(aoi_files) == 0) stop("No Area of Interest file found for the selected country.")
-  aoi_shape  <- sf::st_read(file.path(data_dir, "AoI", aoi_files[[1]]), quiet = TRUE)
+  aoi_shape  <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), country)
   aoi_shape  <- sf::st_transform(aoi_shape, crs = 4326)
   aoi_bounds <- sf::st_bbox(aoi_shape)
 

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -751,12 +751,19 @@ compute_ndvi_explorer_stats <- function(train_ndvi_df, test_ndvi_df) {
     if (!is.null(sen)) sen_slope <- as.numeric(sen$estimates)[1]
   }
 
+  train_year_min <- if (nrow(train_monthly) > 0) min(lubridate::year(train_monthly$YearMonth)) else NA_integer_
+  train_year_max <- if (nrow(train_monthly) > 0) max(lubridate::year(train_monthly$YearMonth)) else NA_integer_
+  test_year      <- if (nrow(test_monthly)  > 0) lubridate::year(test_monthly$YearMonth[1])   else NA_integer_
+
   list(
     wilcox_p = wilcox_p,
     wilcox_median = wilcox_median,
     smk_p = smk_p,
     sen_slope = sen_slope,
-    smk_n_months = smk_n_months
+    smk_n_months = smk_n_months,
+    train_year_min = train_year_min,
+    train_year_max = train_year_max,
+    test_year = test_year
   )
 }
 

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -1709,7 +1709,7 @@ plot_ba_maps <- function(data = NULL, month_to_plot = "01",
     mutate(label = ifelse(BurnedArea_Size <= 1, 
                           paste0(Year, "\nBurned Area: 0 km² (0%)"), 
                           paste0(Year, "\nBurned Area: ", round(BurnedArea_Size, 1), " km² (", round(Percentage_Burned, 1), "%)"))) %>%
-    select(Year, label) %>%
+    dplyr::select(Year, label) %>%
     tibble::deframe()
   
   ba_change <- data_filtered %>%
@@ -1723,7 +1723,7 @@ plot_ba_maps <- function(data = NULL, month_to_plot = "01",
                                                    BurnedArea_Size - 0,
                                                    BurnedArea_Size - lag(BurnedArea_Size))))) %>%
            # changeBurnedArea = BurnedArea_Size - lag(BurnedArea_Size)) %>%
-    select(changeBurnedArea) %>%
+    dplyr::select(changeBurnedArea) %>%
     tibble::deframe()
   BurnedArea_change <- round(ba_change[length(ba_change)], 1)
   year_range_label <- if (n_shown >= 2) paste0(min(selected_years), "–", max(selected_years)) else as.character(selected_years)
@@ -2736,15 +2736,17 @@ compute_ba_annual_cold <- function(data_dir, country, resolution, year) {
 #' and save the PNG via the UNMODIFIED plot_ndvi_maps(). Returns TRUE on success,
 #' NULL on failure (short-circuits if the first/most-recent-year call fails).
 generate_2Dmap_hot <- function(country_name, sensor, resolution, map_year, map_month,
-                               figures_dir, figure_filename) {
+                               figures_dir, figure_filename, years_vec = NULL) {
   map_year  <- as.integer(map_year)
   map_month <- as.integer(map_month)
   mm        <- sprintf("%02d", map_month)
-  years_desc <- map_year:(map_year - 3)  # most recent first
+  # Default: most-recent 4 years. A caller (e.g. comparison_image) may pass an
+  # explicit year list instead.
+  if (is.null(years_vec)) years_vec <- map_year:(map_year - 3)
 
   parts <- list()
-  for (i in seq_along(years_desc)) {
-    yr <- years_desc[i]
+  for (i in seq_along(years_vec)) {
+    yr <- years_vec[i]
     g <- try_api_grid_call(
       "/api/v1/ndvi/monthly-grid",
       list(aoi = country_name, sensor = sensor, resolution = resolution,
@@ -2777,15 +2779,15 @@ generate_2Dmap_hot <- function(country_name, sensor, resolution, map_year, map_m
 #' metadata$burned_km2; Percentage_Burned from aoi_area_km2), and save the PNG via
 #' the UNMODIFIED plot_ba_maps(). Returns TRUE on success, NULL on failure.
 generate_ba_2Dmap_hot <- function(country_name, map_year, map_month, figures_dir,
-                                  figure_filename, aoi_area_km2 = NULL) {
+                                  figure_filename, aoi_area_km2 = NULL, years_vec = NULL) {
   map_year  <- as.integer(map_year)
   map_month <- as.integer(map_month)
   mm        <- sprintf("%02d", map_month)
-  years_desc <- map_year:(map_year - 3)
+  if (is.null(years_vec)) years_vec <- map_year:(map_year - 3)
 
   parts <- list()
-  for (i in seq_along(years_desc)) {
-    yr <- years_desc[i]
+  for (i in seq_along(years_vec)) {
+    yr <- years_vec[i]
     g <- try_api_grid_call(
       "/api/v1/burned-area/monthly-grid",
       list(aoi = country_name, year = yr, month = map_month)

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2530,3 +2530,255 @@ plot_annual_ndvi_leaflet <- function(result) {
       opacity  = 0.8
     )
 }
+
+# =============================================================================
+# GRID HOT PATH — per-pixel grid endpoints (annual/monthly NDVI delta, BA maps)
+# =============================================================================
+
+#' HOT PATH for the annual NDVI Delta Map: fetch two annual-mean NDVI grids from
+#' the API and compute the per-pixel delta. Returns a list shaped exactly like
+#' compute_annual_ndvi_change() so plot_annual_ndvi_leaflet() + the summary card
+#' work unchanged. NULL if the API is unavailable (short-circuits after year_a).
+compute_ndvi_delta_hot <- function(aoi, sensor, resolution, year_a, year_b) {
+  grid_a_raw <- try_api_grid_call(
+    "/api/v1/ndvi/annual-grid",
+    list(aoi = aoi, sensor = sensor, resolution = resolution, year = year_a)
+  )
+  if (is.null(grid_a_raw)) return(NULL)  # short-circuit: don't try year_b
+  grid_b_raw <- try_api_grid_call(
+    "/api/v1/ndvi/annual-grid",
+    list(aoi = aoi, sensor = sensor, resolution = resolution, year = year_b)
+  )
+  if (is.null(grid_b_raw)) return(NULL)
+
+  grid_a <- parse_grid_response(grid_a_raw)
+  grid_b <- parse_grid_response(grid_b_raw)
+  if (nrow(grid_a) == 0L || nrow(grid_b) == 0L) return(NULL)
+
+  merged <- merge(grid_a, grid_b, by = c("lat", "lon"), suffixes = c("_a", "_b"))
+  if (nrow(merged) == 0L) return(NULL)
+  merged$delta <- merged$value_b - merged$value_a
+
+  # Pixel area (km^2) from the grid resolution in metres.
+  res_m <- suppressWarnings(as.numeric(grid_a_raw$metadata$resolution))
+  if (is.na(res_m) || res_m <= 0) res_m <- suppressWarnings(as.numeric(resolution))
+  px_km2 <- if (is.na(res_m) || res_m <= 0) NA_real_ else (res_m / 1000)^2
+
+  pos_km2   <- round(sum(merged$delta > 0, na.rm = TRUE) * px_km2, 1)
+  neg_km2   <- round(sum(merged$delta < 0, na.rm = TRUE) * px_km2, 1)
+  total_km2 <- round(nrow(merged) * px_km2, 1)
+
+  delta_df <- data.frame(
+    x = merged$lon, y = merged$lat,
+    ndvi_a = merged$value_a, ndvi_b = merged$value_b, delta = merged$delta
+  )
+  list(delta_df = delta_df, pos_km2 = pos_km2, neg_km2 = neg_km2,
+       total_km2 = total_km2, year_a = year_a, year_b = year_b,
+       country_name = aoi)
+}
+
+#' Render a monthly NDVI anomaly grid (selected month vs same-month historical
+#' baseline) as a diverging-colour Leaflet. `anomaly_df` has lat, lon, value
+#' (NDVI delta from baseline).
+plot_monthly_anomaly_leaflet <- function(anomaly_df, year, month, baseline_years = NULL) {
+  month_label <- month.name[as.integer(month)]
+  quants  <- stats::quantile(anomaly_df$value, c(0.02, 0.98), na.rm = TRUE)
+  max_abs <- max(abs(quants), na.rm = TRUE)
+  if (!is.finite(max_abs) || max_abs == 0) max_abs <- 0.1
+
+  pal <- leaflet::colorNumeric(
+    palette = c("#8B0000", "#CC3300", "#FFFFFF", "#66BB6A", "#1B5E20"),
+    domain  = c(-max_abs, max_abs), na.color = "transparent"
+  )
+  n_base <- length(baseline_years)
+  base_txt <- if (n_base > 0) paste0(" vs ", n_base, "-year baseline") else ""
+
+  leaflet::leaflet(anomaly_df) %>%
+    leaflet::addTiles() %>%
+    leaflet::addCircleMarkers(
+      lng = ~lon, lat = ~lat, radius = 3, stroke = FALSE, fillOpacity = 0.8,
+      fillColor = ~pal(scales::squish(value, c(-max_abs, max_abs))),
+      popup = ~paste0("<b>NDVI anomaly:</b> ", round(value, 3))
+    ) %>%
+    leaflet::addLegend(
+      position = "bottomright",
+      colors   = c(pal(-max_abs), pal(0), pal(max_abs)),
+      labels   = c("Less green than usual", "Typical", "Greener than usual"),
+      title    = paste0(month_label, " ", year, " NDVI anomaly", base_txt),
+      opacity  = 0.8
+    )
+}
+
+#' HOT PATH interactive Leaflet for the BA monthly map, built from a burned-area
+#' monthly grid (value = BurnDate; >0 means burned). Mirrors the look of
+#' build_ba_monthly_leaflet() but renders pixels as markers from the grid.
+build_ba_monthly_leaflet_grid <- function(ba_df, aoi_shape, year, month_num,
+                                          burned_km2 = NULL) {
+  aoi_shape  <- sf::st_transform(aoi_shape, crs = 4326)
+  aoi_bounds <- sf::st_bbox(aoi_shape)
+  month_label <- format(as.Date(paste0(year, "-", sprintf("%02d", month_num), "-01")), "%B %Y")
+
+  m <- leaflet() %>%
+    addProviderTiles(providers$OpenStreetMap,     group = "Street Map") %>%
+    addProviderTiles(providers$Esri.WorldImagery, group = "Satellite") %>%
+    addPolygons(data = aoi_shape, color = "#1B5E20", weight = 2,
+                opacity = 0.9, fillOpacity = 0, label = "Study area boundary",
+                group = "Study Area") %>%
+    fitBounds(aoi_bounds[[1]], aoi_bounds[[2]], aoi_bounds[[3]], aoi_bounds[[4]])
+
+  burned <- ba_df[!is.na(ba_df$value) & ba_df$value > 0, , drop = FALSE]
+  if (nrow(burned) > 0) {
+    burned$burn_date <- format(as.Date(burned$value - 1, origin = paste0(year, "-01-01")), "%B %d, %Y")
+    km2_txt <- if (!is.null(burned_km2)) paste0(" (", round(burned_km2, 1), " km2 burned)") else ""
+    m <- m %>%
+      addCircleMarkers(
+        data = burned, lng = ~lon, lat = ~lat,
+        radius = 3, stroke = FALSE, fillOpacity = 0.75, fillColor = "#E25822",
+        label = ~lapply(paste0("<b>Burned on:</b> ", burn_date), htmltools::HTML),
+        labelOptions = labelOptions(style = list("font-size" = "12px"), direction = "auto"),
+        group = "Burned Area"
+      ) %>%
+      addLegend("bottomright", colors = "#E25822",
+                labels = paste0("Burned Area", km2_txt),
+                title = month_label, opacity = 0.85)
+  } else {
+    m <- m %>% addControl(
+      html = paste0('<div style="background:white;padding:10px 14px;border-radius:4px;',
+                    'border:1px solid #ddd;font-size:13px;color:#555;">',
+                    'No burned area detected in ', month_label, ' for this area.</div>'),
+      position = "topright")
+  }
+  m %>% addLayersControl(
+    baseGroups    = c("Street Map", "Satellite"),
+    overlayGroups = c("Study Area", "Burned Area"),
+    options       = layersControlOptions(collapsed = FALSE), position = "topleft")
+}
+
+#' HOT PATH Leaflet for the NEW BA annual view, built from a burned-area annual
+#' grid (value = burn frequency: 0 none, 1 once, 2+ multiple).
+build_ba_annual_leaflet <- function(ba_df, aoi_shape, year, total_burned_km2 = NULL) {
+  aoi_shape  <- sf::st_transform(aoi_shape, crs = 4326)
+  aoi_bounds <- sf::st_bbox(aoi_shape)
+
+  m <- leaflet() %>%
+    addProviderTiles(providers$OpenStreetMap,     group = "Street Map") %>%
+    addProviderTiles(providers$Esri.WorldImagery, group = "Satellite") %>%
+    addPolygons(data = aoi_shape, color = "#1B5E20", weight = 2,
+                opacity = 0.9, fillOpacity = 0, label = "Study area boundary",
+                group = "Study Area") %>%
+    fitBounds(aoi_bounds[[1]], aoi_bounds[[2]], aoi_bounds[[3]], aoi_bounds[[4]])
+
+  burned <- ba_df[!is.na(ba_df$value) & ba_df$value > 0, , drop = FALSE]
+  if (nrow(burned) > 0) {
+    burned$col <- ifelse(burned$value >= 2, "#7F0000", "#E25822")
+    burned$lab <- ifelse(burned$value >= 2,
+                         paste0("Burned ", burned$value, " times in ", year),
+                         paste0("Burned once in ", year))
+    m <- m %>%
+      addCircleMarkers(
+        data = burned, lng = ~lon, lat = ~lat,
+        radius = 3, stroke = FALSE, fillOpacity = 0.75, fillColor = ~col,
+        label = ~lapply(lab, htmltools::HTML),
+        labelOptions = labelOptions(style = list("font-size" = "12px"), direction = "auto"),
+        group = "Burned Area"
+      ) %>%
+      addLegend("bottomright", colors = c("#E25822", "#7F0000"),
+                labels = c("Burned once", "Burned 2+ times"),
+                title = paste0("Annual burns ", year), opacity = 0.85)
+  } else {
+    m <- m %>% addControl(
+      html = paste0('<div style="background:white;padding:10px 14px;border-radius:4px;',
+                    'border:1px solid #ddd;font-size:13px;color:#555;">',
+                    'No burned area detected in ', year, ' for this area.</div>'),
+      position = "topright")
+  }
+  m %>% addLayersControl(
+    baseGroups    = c("Street Map", "Satellite"),
+    overlayGroups = c("Study Area", "Burned Area"),
+    options       = layersControlOptions(collapsed = FALSE), position = "topleft")
+}
+
+#' HOT PATH for the NDVI facet PNG: fetch one monthly-grid per year for the last
+#' 4 years (selected month), assemble the data frame plot_ndvi_maps() expects,
+#' and save the PNG via the UNMODIFIED plot_ndvi_maps(). Returns TRUE on success,
+#' NULL on failure (short-circuits if the first/most-recent-year call fails).
+generate_2Dmap_hot <- function(country_name, sensor, resolution, map_year, map_month,
+                               figures_dir, figure_filename) {
+  map_year  <- as.integer(map_year)
+  map_month <- as.integer(map_month)
+  mm        <- sprintf("%02d", map_month)
+  years_desc <- map_year:(map_year - 3)  # most recent first
+
+  parts <- list()
+  for (i in seq_along(years_desc)) {
+    yr <- years_desc[i]
+    g <- try_api_grid_call(
+      "/api/v1/ndvi/monthly-grid",
+      list(aoi = country_name, sensor = sensor, resolution = resolution,
+           year = yr, month = map_month)
+    )
+    if (is.null(g)) {
+      if (i == 1L) return(NULL)  # short-circuit: API down on the first call
+      next                       # older year simply has no data for this month
+    }
+    df <- parse_grid_response(g)
+    if (nrow(df) == 0L) next
+    parts[[length(parts) + 1L]] <- data.frame(
+      x = df$lon, y = df$lat, NDVI = df$value,
+      Year = as.character(yr), Month = mm, YearMonth = paste(yr, mm),
+      stringsAsFactors = FALSE
+    )
+  }
+  if (length(parts) == 0L) return(NULL)
+
+  data <- do.call(rbind, parts)
+  plot_ndvi_maps(data = data, month_to_plot = mm,
+                 ncol = length(parts),
+                 save_path = figures_dir, filename = figure_filename)
+  TRUE
+}
+
+#' HOT PATH for the burned-area facet PNG: fetch one burned-area monthly-grid per
+#' year for the last 4 years (selected month), assemble the data frame
+#' plot_ba_maps() expects (BurnedArea 0/1; per-year BurnedArea_Size from
+#' metadata$burned_km2; Percentage_Burned from aoi_area_km2), and save the PNG via
+#' the UNMODIFIED plot_ba_maps(). Returns TRUE on success, NULL on failure.
+generate_ba_2Dmap_hot <- function(country_name, map_year, map_month, figures_dir,
+                                  figure_filename, aoi_area_km2 = NULL) {
+  map_year  <- as.integer(map_year)
+  map_month <- as.integer(map_month)
+  mm        <- sprintf("%02d", map_month)
+  years_desc <- map_year:(map_year - 3)
+
+  parts <- list()
+  for (i in seq_along(years_desc)) {
+    yr <- years_desc[i]
+    g <- try_api_grid_call(
+      "/api/v1/burned-area/monthly-grid",
+      list(aoi = country_name, year = yr, month = map_month)
+    )
+    if (is.null(g)) {
+      if (i == 1L) return(NULL)  # short-circuit: API down on the first call
+      next
+    }
+    df <- parse_grid_response(g)
+    if (nrow(df) == 0L) next
+    burned_km2 <- suppressWarnings(as.numeric(g$metadata$burned_km2))
+    if (length(burned_km2) == 0L) burned_km2 <- NA_real_
+    pct <- if (!is.null(aoi_area_km2) && !is.na(aoi_area_km2) && aoi_area_km2 > 0 &&
+               !is.na(burned_km2)) burned_km2 / aoi_area_km2 * 100 else 0
+    parts[[length(parts) + 1L]] <- data.frame(
+      x = df$lon, y = df$lat,
+      BurnedArea = as.integer(df$value > 0),
+      Month = mm, Year = as.character(yr), YearMonth = paste(yr, mm),
+      BurnedArea_Size = burned_km2, Percentage_Burned = pct,
+      stringsAsFactors = FALSE
+    )
+  }
+  if (length(parts) == 0L) return(NULL)
+
+  data <- do.call(rbind, parts)
+  plot_ba_maps(data = data, month_to_plot = mm, n_years = 4,
+               save_path = figures_dir, filename = figure_filename)
+  TRUE
+}

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2262,7 +2262,7 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
         position      = "topleft"
       )
 
-    return(list(map = m, years_label = years_label, n_years = n_years))
+    return(list(map = m, years_label = years_label, n_years = n_years, data_source = "api"))
   }
 
   ba_files <- list.files(data_path, pattern = "\\.tif$", full.names = TRUE)
@@ -2349,7 +2349,7 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
       position      = "topleft"
     )
 
-  list(map = m, years_label = years_label, n_years = n_years)
+  list(map = m, years_label = years_label, n_years = n_years, data_source = "tif")
 }
 
 # Function to plot delta NDVI on a Leaflet map

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2206,6 +2206,59 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
   aoi_shape  <- sf::st_transform(aoi_shape, crs = 4326)
   aoi_bounds <- sf::st_bbox(aoi_shape)
 
+  # HOT PATH: pre-computed FRP polygons + year-range metadata from the API. The
+  # GeoJSON carries return period in `frp_years`; the year range comes from the
+  # response metadata. Returns early; the TIF computation below is the fallback
+  # and runs unchanged when the API is unavailable.
+  frp_api <- try_api_geometry(
+    endpoint        = "/api/v1/geometry/fire-return-period",
+    params          = list(aoi = country),
+    return_metadata = TRUE
+  )
+  if (!is.null(frp_api) && inherits(frp_api$geometry, "sf") &&
+      "frp_years" %in% names(frp_api$geometry) && nrow(frp_api$geometry) > 0 &&
+      !is.null(frp_api$metadata$n_years)) {
+    frp_sf <- sf::st_transform(frp_api$geometry, 4326)
+    frp_sf$return_period <- frp_sf$frp_years
+    years_label <- paste(frp_api$metadata$year_start, "to", frp_api$metadata$year_end)
+    n_years     <- frp_api$metadata$n_years
+
+    pal <- leaflet::colorNumeric(
+      palette  = rev(RColorBrewer::brewer.pal(9, "YlOrRd")),
+      domain   = c(1, max(frp_sf$return_period, na.rm = TRUE)),
+      na.color = "transparent"
+    )
+    rp_vals <- round(frp_sf$return_period, 1)
+    m <- leaflet() %>%
+      addProviderTiles(providers$OpenStreetMap,     group = "Street Map") %>%
+      addProviderTiles(providers$Esri.WorldImagery, group = "Satellite") %>%
+      addPolygons(
+        data         = frp_sf,
+        fillColor    = ~pal(return_period), fillOpacity = 0.8,
+        color        = NA, weight = 0,
+        label        = lapply(paste0(
+          "<b>Burns approximately every ", rp_vals, " year",
+          ifelse(rp_vals == 1, "", "s"), "</b>"
+        ), htmltools::HTML),
+        labelOptions = labelOptions(style = list("font-size" = "12px"), direction = "auto"),
+        group        = "Fire Return Period"
+      ) %>%
+      addPolygons(data = aoi_shape, color = "#1B5E20", weight = 2,
+                  opacity = 0.9, fillOpacity = 0, group = "Study Area") %>%
+      fitBounds(aoi_bounds[[1]], aoi_bounds[[2]], aoi_bounds[[3]], aoi_bounds[[4]]) %>%
+      addLegend("bottomright", pal = pal, values = frp_sf$return_period,
+                title   = "Fire Return Period<br>(years)", opacity = 0.85,
+                labFormat = labelFormat(suffix = " yrs", digits = 1)) %>%
+      addLayersControl(
+        baseGroups    = c("Street Map", "Satellite"),
+        overlayGroups = c("Study Area", "Fire Return Period"),
+        options       = layersControlOptions(collapsed = FALSE),
+        position      = "topleft"
+      )
+
+    return(list(map = m, years_label = years_label, n_years = n_years))
+  }
+
   ba_files <- list.files(data_path, pattern = "\\.tif$", full.names = TRUE)
   if (length(ba_files) == 0) {
     stop("No burned area data found for this area and resolution. Please try a different selection.")

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2698,6 +2698,39 @@ build_ba_annual_leaflet <- function(ba_df, aoi_shape, year, total_burned_km2 = N
     options       = layersControlOptions(collapsed = FALSE), position = "topleft")
 }
 
+#' COLD PATH for the BA annual view: compute per-pixel burn frequency for one
+#' year directly from the monthly burned-area TIFs (fallback when the API is
+#' down). Returns list(df = data.frame(lat, lon, value = months-burned count),
+#' total_burned_km2, aoi_shape) or NULL if no TIFs exist for the year.
+compute_ba_annual_cold <- function(data_dir, country, resolution, year) {
+  data_path <- file.path(data_dir, "BurnedArea", country, paste0(resolution, "m_resolution"))
+  ba_files  <- list.files(data_path, pattern = "\\.tif$", full.names = TRUE)
+  yr_files  <- ba_files[grepl(paste0("^", year, "-"), basename(ba_files))]
+  if (length(yr_files) == 0L) return(NULL)
+
+  # Per-pixel count of months burned (BurnDate > 0) across the year.
+  monthly  <- terra::ifel(terra::rast(yr_files) > 0, 1, 0)
+  burn_cnt <- terra::app(monthly, fun = sum, na.rm = TRUE)
+  burn_cnt <- terra::project(burn_cnt, "EPSG:4326")
+
+  aoi_files <- list.files(file.path(data_dir, "AoI"),
+                          pattern = paste0("AoI.*", country, ".*\\.geojson$"))
+  if (length(aoi_files) == 0L) stop("No Area of Interest file found for the selected country.")
+  aoi_shape <- read_aoi_geometry(file.path(data_dir, "AoI", aoi_files[[1]]), country)
+  aoi_4326  <- sf::st_transform(aoi_shape, 4326)
+  burn_cnt  <- terra::mask(burn_cnt, terra::vect(aoi_4326))
+
+  df <- as.data.frame(burn_cnt, xy = TRUE)
+  names(df) <- c("lon", "lat", "value")
+  df <- df[!is.na(df$value), c("lat", "lon", "value"), drop = FALSE]
+  if (nrow(df) == 0L) return(NULL)
+
+  px_km2 <- (suppressWarnings(as.numeric(gsub("[^0-9]", "", resolution))) / 1000)^2
+  total_burned_km2 <- round(sum(df$value > 0) * px_km2, 1)
+
+  list(df = df, total_burned_km2 = total_burned_km2, aoi_shape = aoi_4326)
+}
+
 #' HOT PATH for the NDVI facet PNG: fetch one monthly-grid per year for the last
 #' 4 years (selected month), assemble the data frame plot_ndvi_maps() expects,
 #' and save the PNG via the UNMODIFIED plot_ndvi_maps(). Returns TRUE on success,

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2257,7 +2257,8 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
         group        = "Fire Return Period"
       ) %>%
       addPolygons(data = aoi_shape, color = "#1B5E20", weight = 2,
-                  opacity = 0.9, fillOpacity = 0, group = "Study Area") %>%
+                  opacity = 0.9, fillOpacity = 0, group = "Study Area",
+                  options = pathOptions(interactive = FALSE)) %>%
       fitBounds(aoi_bounds[[1]], aoi_bounds[[2]], aoi_bounds[[3]], aoi_bounds[[4]]) %>%
       addLegend("bottomright", pal = pal, values = frp_sf$return_period,
                 title   = "Fire Return Period<br>(years)", opacity = 0.85,
@@ -2344,7 +2345,8 @@ build_ba_frp_leaflet <- function(data_dir = NULL, country = NULL, resolution = N
       group        = "Fire Return Period"
     ) %>%
     addPolygons(data = aoi_shape, color = "#1B5E20", weight = 2,
-                opacity = 0.9, fillOpacity = 0, group = "Study Area") %>%
+                opacity = 0.9, fillOpacity = 0, group = "Study Area",
+                options = pathOptions(interactive = FALSE)) %>%
     fitBounds(aoi_bounds[[1]], aoi_bounds[[2]], aoi_bounds[[3]], aoi_bounds[[4]]) %>%
     addLegend("bottomright", pal = pal, values = polys_rp$return_period,
               title   = "Fire Return Period<br>(years)", opacity = 0.85,

--- a/app/src/visualization.R
+++ b/app/src/visualization.R
@@ -2339,9 +2339,8 @@ plot_delta_ndvi_streetview <- function(data = NULL, month_to_plot = "01",
 # Compute per-pixel annual mean NDVI delta between two years
 compute_annual_ndvi_change <- function(year_a, year_b, country_name, resolution, data_dir) {
   data_path <- file.path(data_dir, "NDVI", country_name, paste0(resolution, "m_resolution"))
-  aoi_country <- sub("_.*", "", country_name)
-  aoi_path    <- file.path(data_dir, "AoI")
-  aoi_files   <- get_filenames(aoi_path, "AoI", ".geojson", aoi_country)
+  aoi_path  <- file.path(data_dir, "AoI")
+  aoi_files <- get_filenames(aoi_path, "AoI", ".geojson", country_name)
   aoi_proj    <- get_aoi_vector(aoi_files[[1]], aoi_path, "EPSG:4326")
 
   ndvi_files <- get_filenames(data_path, "NDVI", ".tif", country_name)

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -99,6 +99,10 @@ mod_body_ui <- function(id) {
                                          uiOutput("ndvi_health_summary_card"),
                                          uiOutput("ndvi_annual_summary_card"),
                                          uiOutput("ndvi_ts_plot_container"),
+                                         tags$p(
+                                           style = "font-size:0.8em; color:#888; margin-top:4px;",
+                                           textOutput("ds_label_ndvi_ts", inline = TRUE)
+                                         ),
                                          div(
                                            class = "ndvi-ts-insight-cards",
                                            style = "margin-top: 16px;",
@@ -118,7 +122,11 @@ mod_body_ui <- function(id) {
                                            div(class = "ndvi-callout",
                                                p("This chart shows vegetation health for each land cover type throughout the year. Each coloured line represents one type - click the legend to show or hide classes. Use the map on the right to see where each type is located.")),
                                            mod_busy_spinner_ui("busy_spinner"),
-                                           uiOutput("lc_plot_container"))
+                                           uiOutput("lc_plot_container"),
+                                           tags$p(
+                                             style = "font-size:0.8em; color:#888; margin-top:4px;",
+                                             textOutput("ds_label_lc", inline = TRUE)
+                                           ))
                       ),
                     ),
 
@@ -187,7 +195,11 @@ mod_body_ui <- function(id) {
                                              ),
 
                                              mod_busy_spinner_ui("busy_spinner"),
-                                             uiOutput("ba_plot_container")
+                                             uiOutput("ba_plot_container"),
+                                             tags$p(
+                                               style = "font-size:0.8em; color:#888; margin-top:4px;",
+                                               textOutput("ds_label_ba_seasonal", inline = TRUE)
+                                             )
                                            ),
 
                                            # === DAILY ACTIVITY ===
@@ -198,7 +210,11 @@ mod_body_ui <- function(id) {
                                              ),
 
                                              mod_busy_spinner_ui("busy_spinner"),
-                                             uiOutput("ba_daily_plot_container")
+                                             uiOutput("ba_daily_plot_container"),
+                                             tags$p(
+                                               style = "font-size:0.8em; color:#888; margin-top:4px;",
+                                               textOutput("ds_label_ba_daily", inline = TRUE)
+                                             )
                                            ),
                                        )
                       )
@@ -295,7 +311,11 @@ mod_body_ui <- function(id) {
                         HTML("⚠️ <strong>Note:</strong> Flooded vegetation's variability is driven by water levels, not vegetation stress — interpret it differently."))
                   ),
                   mod_busy_spinner_ui("busy_spinner"),
-                  uiOutput("scenario_productivity_container")
+                  uiOutput("scenario_productivity_container"),
+                  tags$p(
+                    style = "font-size:0.8em; color:#888; margin-top:4px;",
+                    textOutput("ds_label_productivity", inline = TRUE)
+                  )
               )
             )
           ),
@@ -307,7 +327,11 @@ mod_body_ui <- function(id) {
               condition = "input.tabs == 'ScenarioExplorerTab' && input.scenariosubtabs == 'ScenarioAnomalyResilience'",
               div(class="plot-container",
                   mod_busy_spinner_ui("busy_spinner"),
-                  uiOutput("scenario_anomaly_container")
+                  uiOutput("scenario_anomaly_container"),
+                  tags$p(
+                    style = "font-size:0.8em; color:#888; margin-top:4px;",
+                    textOutput("ds_label_anomaly", inline = TRUE)
+                  )
               )
             )
           ),
@@ -319,7 +343,11 @@ mod_body_ui <- function(id) {
               div(class="plot-container",
                   uiOutput("agri_callout"),
                   mod_busy_spinner_ui("busy_spinner"),
-                  uiOutput("scenario_agri_container")
+                  uiOutput("scenario_agri_container"),
+                  tags$p(
+                    style = "font-size:0.8em; color:#888; margin-top:4px;",
+                    textOutput("ds_label_agri", inline = TRUE)
+                  )
               )
             )
           )

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -381,61 +381,74 @@ mod_body_ui <- function(id) {
         value = "AIassistantTab",
         div(
           class = "plot-container",
-          tags$style(HTML("
-            .ai-chat { min-height: 320px; max-height: 60vh; overflow-y: auto;
-                       padding: 10px; border: 1px solid #e0e0e0; border-radius: 6px;
-                       background: #fafafa; }
-            .ai-row { display: flex; }
-            .ai-row.user  { justify-content: flex-end; }
-            .ai-row.agent { justify-content: flex-start; }
-            .ai-bubble { display: inline-block; padding: 8px 12px; border-radius: 12px;
-                         margin: 6px 0; max-width: 80%; font-size: 0.92em;
-                         line-height: 1.35; white-space: pre-wrap; word-wrap: break-word; }
-            .ai-bubble.user  { background: #1B5E20; color: #ffffff;
-                               border-bottom-right-radius: 2px; }
-            .ai-bubble.agent { background: #eceff1; color: #1f2d1f;
-                               border-bottom-left-radius: 2px; }
-            .ai-empty { color: #888; font-style: italic; padding: 16px; }
-          ")),
           fluidRow(
             column(
-              4,
-              selectInput(
-                "llm_provider", "AI provider",
-                choices = c("Anthropic (Claude)" = "anthropic",
-                            "OpenAI (GPT-4o)"     = "openai")
-              ),
-              conditionalPanel(
-                condition = "output.server_key_configured == false",
-                wellPanel(
-                  passwordInput("user_api_key", "Your API key",
-                                placeholder = "sk-... or sk-ant-..."),
-                  helpText("Used for this session only. Never stored.")
+              12,
+              # --- Collapsible settings panel (full width, above the chat) ---
+              div(
+                class = "ai-settings",
+                div(
+                  class = "ai-settings-header",
+                  tags$span(class = "ai-settings-title", "Assistant settings"),
+                  actionButton("toggle_settings", "Settings ▲",
+                               class = "btn-default btn-sm ai-settings-toggle")
+                ),
+                conditionalPanel(
+                  condition = "output.settings_expanded == true",
+                  selectInput(
+                    "llm_provider", "AI provider",
+                    choices = c("Anthropic (Claude)" = "anthropic",
+                                "OpenAI (GPT-4o)"     = "openai")
+                  ),
+                  conditionalPanel(
+                    condition = "output.server_key_configured == false",
+                    passwordInput("user_api_key", "Your API key",
+                                  placeholder = "sk-... or sk-ant-..."),
+                    helpText("Used for this session only. Never stored.")
+                  ),
+                  conditionalPanel(
+                    condition = "output.server_key_configured == true",
+                    p(tags$span(style = "color:#2E7D32; font-weight:bold;", "● "),
+                      "AI Assistant ready")
+                  )
+                ),
+                conditionalPanel(
+                  condition = "output.settings_expanded == false",
+                  div(class = "ai-settings-summary",
+                      textOutput("settings_summary", inline = TRUE))
                 )
               ),
-              conditionalPanel(
-                condition = "output.server_key_configured == true",
-                wellPanel(
-                  p(tags$span(style = "color:#2E7D32; font-weight:bold;", "● "),
-                    "AI Assistant ready")
-                )
-              ),
-              wellPanel(
-                h5("Current context"),
-                textOutput("context_summary")
-              )
-            ),
-            column(
-              8,
+
+              # --- Conversation (full width) ---
               uiOutput("conversation_display"),
               hr(),
+
+              # --- Input area (full width) ---
               textAreaInput(
                 "user_question", NULL,
                 placeholder = "Ask about vegetation trends, fire patterns, land cover changes...",
                 rows = 3, width = "100%"
               ),
-              actionButton("send_question", "Ask", class = "action_button"),
-              actionButton("clear_history", "Clear conversation", class = "btn-default btn-sm")
+              div(
+                class = "ai-input-actions",
+                actionButton("send_question", "Ask", class = "action_button ai-send-btn"),
+                actionButton("clear_history", "Clear conversation",
+                             class = "btn-default ai-clear-btn")
+              ),
+              tags$p(class = "ai-input-hint", "Press Ctrl + Enter (⌘ + Enter on Mac) to send."),
+
+              # Send on Ctrl/Cmd + Enter from the question box
+              tags$script(HTML(
+                "document.addEventListener('keydown', function(e){
+                   var ta = document.getElementById('user_question');
+                   if (ta && document.activeElement === ta &&
+                       (e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                     e.preventDefault();
+                     var btn = document.getElementById('send_question');
+                     if (btn) btn.click();
+                   }
+                 });"
+              ))
             )
           )
         )

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -234,7 +234,7 @@ mod_body_ui <- function(id) {
                                            shinyWidgets::radioGroupButtons(
                                              inputId  = "ba_map_view",
                                              label    = NULL,
-                                             choices  = c("Monthly View" = "monthly", "Fire Return Period" = "frp"),
+                                             choices  = c("Monthly View" = "monthly", "Annual View" = "annual", "Fire Return Period" = "frp"),
                                              selected = "monthly",
                                              size     = "sm",
                                              status   = "default"
@@ -277,6 +277,17 @@ mod_body_ui <- function(id) {
                                              # Busy Spinner always available for this tab
                                              mod_busy_spinner_ui("busy_spinner"),
                                              leafletOutput("ba_frp_leaflet", height = "450px")
+                                           ),
+
+                                           # === ANNUAL VIEW (API hot path only) ===
+                                           conditionalPanel(
+                                             condition = "input.ba_map_view == 'annual'",
+                                             div(class="infobox",
+                                                 p("This map shows how much of the study area burned across all months of the selected year. Orange = burned once; dark red = burned more than once. Requires the live data service.")
+                                             ),
+                                             uiOutput("ba_annual_summary"),
+                                             mod_busy_spinner_ui("busy_spinner"),
+                                             leafletOutput("ba_annual_leaflet", height = "450px")
                                            ),
 
                                            # Data-source label (shared across Monthly + FRP views)

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -11,7 +11,22 @@ mod_body_ui <- function(id) {
              position:fixed;
              top: calc(50%);
              left: calc(50% - 100px);
-             max-width: 300px}"))
+             max-width: 300px}")),
+      # MathJax: render LaTeX formulas in agent responses. Config must load
+      # BEFORE the library; enable $...$ inline + $$...$$ display delimiters.
+      tags$script(HTML(
+        "window.MathJax = {
+           tex: {
+             inlineMath:  [['$', '$'], ['\\\\(', '\\\\)']],
+             displayMath: [['$$', '$$'], ['\\\\[', '\\\\]']]
+           },
+           options: { skipHtmlTags: ['script','noscript','style','textarea','pre','code'] }
+         };"
+      )),
+      tags$script(
+        src = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js",
+        async = NA
+      )
     ),
 
     # Tabset with panels for separate pasted (nested, currently one for the NDVI Explorer and one for the BA Explorer)

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -156,7 +156,11 @@ mod_body_ui <- function(id) {
                                 p("This map compares annual average vegetation health between two selected years. Green = vegetation gaining. Red = vegetation declining. Use it to identify long-term gains and losses across the landscape."))
                           ),
                           mod_busy_spinner_ui("busy_spinner"),
-                          uiOutput("dm_plot_container")
+                          uiOutput("dm_plot_container"),
+                          tags$p(
+                            style = "font-size:0.8em; color:#888; margin-top:4px;",
+                            textOutput("ds_label_ndvi_delta", inline = TRUE)
+                          )
                         )
                       )
                     ),
@@ -273,6 +277,12 @@ mod_body_ui <- function(id) {
                                              # Busy Spinner always available for this tab
                                              mod_busy_spinner_ui("busy_spinner"),
                                              leafletOutput("ba_frp_leaflet", height = "450px")
+                                           ),
+
+                                           # Data-source label (shared across Monthly + FRP views)
+                                           tags$p(
+                                             style = "font-size:0.8em; color:#888; margin-top:4px;",
+                                             textOutput("ds_label_ba_map", inline = TRUE)
                                            ),
 
                                        )

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -451,6 +451,8 @@ mod_body_ui <- function(id) {
                              class = "btn-default ai-clear-btn")
               ),
               tags$p(class = "ai-input-hint", "Press Ctrl + Enter (⌘ + Enter on Mac) to send."),
+              tags$p(class = "ai-disclaimer",
+                     "AI-generated responses may be inaccurate — double-check key figures against the explorer data. Questions are sent to a third-party AI provider."),
 
               # Send on Ctrl/Cmd + Enter from the question box
               tags$script(HTML(

--- a/app/ui/mod_body_ui.R
+++ b/app/ui/mod_body_ui.R
@@ -362,6 +362,72 @@ mod_body_ui <- function(id) {
             )
           )
         )
+      ),
+
+      # AI Assistant (standalone chat tab; existing tabs unchanged)
+      tabPanel(
+        title = "AI Assistant",
+        value = "AIassistantTab",
+        div(
+          class = "plot-container",
+          tags$style(HTML("
+            .ai-chat { min-height: 320px; max-height: 60vh; overflow-y: auto;
+                       padding: 10px; border: 1px solid #e0e0e0; border-radius: 6px;
+                       background: #fafafa; }
+            .ai-row { display: flex; }
+            .ai-row.user  { justify-content: flex-end; }
+            .ai-row.agent { justify-content: flex-start; }
+            .ai-bubble { display: inline-block; padding: 8px 12px; border-radius: 12px;
+                         margin: 6px 0; max-width: 80%; font-size: 0.92em;
+                         line-height: 1.35; white-space: pre-wrap; word-wrap: break-word; }
+            .ai-bubble.user  { background: #1B5E20; color: #ffffff;
+                               border-bottom-right-radius: 2px; }
+            .ai-bubble.agent { background: #eceff1; color: #1f2d1f;
+                               border-bottom-left-radius: 2px; }
+            .ai-empty { color: #888; font-style: italic; padding: 16px; }
+          ")),
+          fluidRow(
+            column(
+              4,
+              selectInput(
+                "llm_provider", "AI provider",
+                choices = c("Anthropic (Claude)" = "anthropic",
+                            "OpenAI (GPT-4o)"     = "openai")
+              ),
+              conditionalPanel(
+                condition = "output.server_key_configured == false",
+                wellPanel(
+                  passwordInput("user_api_key", "Your API key",
+                                placeholder = "sk-... or sk-ant-..."),
+                  helpText("Used for this session only. Never stored.")
+                )
+              ),
+              conditionalPanel(
+                condition = "output.server_key_configured == true",
+                wellPanel(
+                  p(tags$span(style = "color:#2E7D32; font-weight:bold;", "● "),
+                    "AI Assistant ready")
+                )
+              ),
+              wellPanel(
+                h5("Current context"),
+                textOutput("context_summary")
+              )
+            ),
+            column(
+              8,
+              uiOutput("conversation_display"),
+              hr(),
+              textAreaInput(
+                "user_question", NULL,
+                placeholder = "Ask about vegetation trends, fire patterns, land cover changes...",
+                rows = 3, width = "100%"
+              ),
+              actionButton("send_question", "Ask", class = "action_button"),
+              actionButton("clear_history", "Clear conversation", class = "btn-default btn-sm")
+            )
+          )
+        )
       )
     )
   )

--- a/app/ui/mod_sidebar_ui.R
+++ b/app/ui/mod_sidebar_ui.R
@@ -51,28 +51,33 @@ mod_sidebar_ui <- function(id) {
                                 "Stara Planina, Bulgaria" = "Bulgaria", "Kasigau, Kenya" = "Kenya")), # Add more countries as needed
         leafletOutput("map", height = "165px"), # Adds leaflet map for the AoI
         br(),
-        conditionalPanel(
-          condition = "!(
-            (input.tabs == 'ScenarioExplorerTab' && (input.scenariosubtabs == 'ScenarioAgriculturalMonitoring' || input.scenariosubtabs == 'ScenarioAnomalyResilience')) ||
-            (input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab' && input.ndvi_ts_view == 'annual') ||
-            (input.tabs == 'BAexplorerTab' && input.basubtabs == 'BAtimeseries' && input.ba_ts_view == 'daily')
-          )",
-          selectInput("year", "Select year", selected = NULL, choices = NULL)
-        ),
-        conditionalPanel(
-          condition = "!(
-            (input.tabs == 'ScenarioExplorerTab' && (input.scenariosubtabs == 'ScenarioAgriculturalMonitoring' || input.scenariosubtabs == 'ScenarioAnomalyResilience' || input.scenariosubtabs == 'ScenarioLandCoverProductivity')) ||
-            (input.tabs == 'NDVIexplorerTab' && (input.ndvisubtabs == 'NDVItsTab' || input.ndvisubtabs == 'LCexplorerTab' || (input.ndvisubtabs == 'NDVIdeltaTab' && input.ndvi_delta_view == 'annual'))) ||
-            (input.tabs == 'BAexplorerTab' && input.basubtabs == 'BAtimeseries')
-          )",
-          shinyjs::disabled(selectInput("month", "Select month",
-                                        selected = "January",
-                                        choices  = month.name[1:lubridate::month(Sys.Date())-1]))
-        ),
-        selectInput("resolution", "Select spatial resolution (m)", 
-                    selected = "1000 (ESA Sentinel-2)", 
-                    choices = c("1000 (ESA Sentinel-2)" = "Sentinel_1000", "1000 (Terra MODIS)" = "MODIS_1000",
-                                "500 (Terra MODIS)" = "500", "250 (Terra MODIS)" = "250", "100 (ESA Sentinel-2)" = "100"))
+        # Data filters (year/month/resolution) — hidden on the AI Assistant tab
+        # via shinyjs (server.R observes input$tabs). AoI selector + map stay above.
+        div(
+          id = "sidebar_filters",
+          conditionalPanel(
+            condition = "!(
+              (input.tabs == 'ScenarioExplorerTab' && (input.scenariosubtabs == 'ScenarioAgriculturalMonitoring' || input.scenariosubtabs == 'ScenarioAnomalyResilience')) ||
+              (input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab' && input.ndvi_ts_view == 'annual') ||
+              (input.tabs == 'BAexplorerTab' && input.basubtabs == 'BAtimeseries' && input.ba_ts_view == 'daily')
+            )",
+            selectInput("year", "Select year", selected = NULL, choices = NULL)
+          ),
+          conditionalPanel(
+            condition = "!(
+              (input.tabs == 'ScenarioExplorerTab' && (input.scenariosubtabs == 'ScenarioAgriculturalMonitoring' || input.scenariosubtabs == 'ScenarioAnomalyResilience' || input.scenariosubtabs == 'ScenarioLandCoverProductivity')) ||
+              (input.tabs == 'NDVIexplorerTab' && (input.ndvisubtabs == 'NDVItsTab' || input.ndvisubtabs == 'LCexplorerTab' || (input.ndvisubtabs == 'NDVIdeltaTab' && input.ndvi_delta_view == 'annual'))) ||
+              (input.tabs == 'BAexplorerTab' && input.basubtabs == 'BAtimeseries')
+            )",
+            shinyjs::disabled(selectInput("month", "Select month",
+                                          selected = "January",
+                                          choices  = month.name[1:lubridate::month(Sys.Date())-1]))
+          ),
+          selectInput("resolution", "Select spatial resolution (m)",
+                      selected = "1000 (ESA Sentinel-2)",
+                      choices = c("1000 (ESA Sentinel-2)" = "Sentinel_1000", "1000 (Terra MODIS)" = "MODIS_1000",
+                                  "500 (Terra MODIS)" = "500", "250 (Terra MODIS)" = "250", "100 (ESA Sentinel-2)" = "100"))
+        )
         ),
     
     # NDVI Time Series page-specific selector and button

--- a/app/ui/mod_sidebar_ui.R
+++ b/app/ui/mod_sidebar_ui.R
@@ -83,18 +83,18 @@ mod_sidebar_ui <- function(id) {
     # NDVI Time Series page-specific selector and button
     conditionalPanel(condition = "input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab'",
                      div(
-                       selectInput("ndvi_ts_lc_class", "Filter by land cover",
-                                   choices = c(
-                                     "Overall (all land cover)" = "",
-                                     "Crops"               = "Crops",
-                                     "Rangeland"           = "Rangeland",
-                                     "Water"               = "Water",
-                                     "Trees"               = "Trees",
-                                     "Flooded vegetation"  = "Flooded_vegetation",
-                                     "Built area"          = "Built_Area",
-                                     "Bare ground"         = "Bare_ground"
-                                   ),
-                                   selected = ""),
+                       selectizeInput("ndvi_ts_lc_class", "Filter by land cover",
+                                      choices = c(
+                                        "Overall (all land cover)" = "all",
+                                        "Crops"               = "Crops",
+                                        "Rangeland"           = "Rangeland",
+                                        "Water"               = "Water",
+                                        "Trees"               = "Trees",
+                                        "Flooded vegetation"  = "Flooded_vegetation",
+                                        "Built area"          = "Built_Area",
+                                        "Bare ground"         = "Bare_ground"
+                                      ),
+                                      selected = "all"),
                        actionButton("generate_ndvi_ts_figures", "Generate Figure", class = "action_button")
                      )),
     

--- a/app/ui/mod_sidebar_ui.R
+++ b/app/ui/mod_sidebar_ui.R
@@ -54,7 +54,8 @@ mod_sidebar_ui <- function(id) {
         conditionalPanel(
           condition = "!(
             (input.tabs == 'ScenarioExplorerTab' && (input.scenariosubtabs == 'ScenarioAgriculturalMonitoring' || input.scenariosubtabs == 'ScenarioAnomalyResilience')) ||
-            (input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab' && input.ndvi_ts_view == 'annual')
+            (input.tabs == 'NDVIexplorerTab' && input.ndvisubtabs == 'NDVItsTab' && input.ndvi_ts_view == 'annual') ||
+            (input.tabs == 'BAexplorerTab' && input.basubtabs == 'BAtimeseries' && input.ba_ts_view == 'daily')
           )",
           selectInput("year", "Select year", selected = NULL, choices = NULL)
         ),

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -741,8 +741,35 @@ table.lc-landcover-tooltip-table thead tr {
 /* Full-width row for charts/tables/maps rendered under a message (Phase 2B) */
 .ai-output-row {
   width: 100%;
-  margin: 8px 0;
-  min-height: 200px;
+  margin: 8px 0 16px 0;
+  clear: both;
+}
+.ai-output-placeholder {
+  background: #f8f9fa;
+  border: 1px dashed #ced4da;
+  border-radius: 6px;
+  padding: 12px 16px;
+  color: #6c757d;
+  font-size: 0.9em;
+}
+.ai-output-chart {
+  min-height: 350px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.ai-output-table {
+  max-height: 400px;
+  overflow-y: auto;
+  border-radius: 6px;
+}
+.ai-output-map {
+  height: 400px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.ai-output-image {
+  width: 100%;
+  border-radius: 6px;
 }
 
 /* Collapsible settings panel */

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -730,7 +730,11 @@ table.lc-landcover-tooltip-table thead tr {
   word-wrap: break-word;
 }
 .ai-bubble.user  { background: #1B5E20; color: #ffffff; border-bottom-right-radius: 2px; }
-.ai-bubble.agent { background: #eceff1; color: #1f2d1f; border-bottom-left-radius: 2px; }
+.ai-bubble.agent { background: #eceff1; color: #1f2d1f; border-bottom-left-radius: 2px;
+                   white-space: normal; }  /* HTML content controls its own wrapping */
+/* No extra space above the first / below the last block inside a bubble */
+.ai-bubble > :first-child { margin-top: 0; }
+.ai-bubble > :last-child  { margin-bottom: 0; }
 .ai-empty {
   color: #8a8f8a;
   font-style: italic;
@@ -809,6 +813,30 @@ table.lc-landcover-tooltip-table thead tr {
 }
 .ai-settings-toggle.btn:hover { background: #e6ebe7 !important; }
 .ai-settings-summary { color: #555; font-size: 0.92em; margin-top: 2px; }
+
+/* Rendered markdown tables inside chat bubbles */
+.ai-bubble table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 8px 0;
+  font-size: 0.88em;
+}
+.ai-bubble table th {
+  background-color: #2d6a4f;
+  color: white;
+  padding: 6px 10px;
+  text-align: left;
+}
+.ai-bubble table td {
+  padding: 5px 10px;
+  border-bottom: 1px solid #dee2e6;
+}
+.ai-bubble table tr:nth-child(even) {
+  background-color: #f8f9fa;
+}
+.ai-bubble table tr:hover {
+  background-color: #e9ecef;
+}
 
 /* Input actions: prominent Ask (grows) + compact Clear on one row */
 .ai-input-actions {

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -857,6 +857,7 @@ table.lc-landcover-tooltip-table thead tr {
 }
 .ai-clear-btn.btn:hover { background: #e6ebe7 !important; }
 .ai-input-hint { color: #9aa09a; font-size: 0.8em; margin: 4px 2px 0; }
+.ai-disclaimer { color: #9aa09a; font-size: 0.78em; font-style: italic; margin: 2px 2px 0; line-height: 1.35; }
 
 /* Ensure all options in the land cover selectize dropdown are left-aligned */
 #ndvi_ts_lc_class + .selectize-control .selectize-dropdown .option,

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -857,3 +857,9 @@ table.lc-landcover-tooltip-table thead tr {
 }
 .ai-clear-btn.btn:hover { background: #e6ebe7 !important; }
 .ai-input-hint { color: #9aa09a; font-size: 0.8em; margin: 4px 2px 0; }
+
+/* Ensure all options in the land cover selectize dropdown are left-aligned */
+#ndvi_ts_lc_class + .selectize-control .selectize-dropdown .option,
+#ndvi_ts_lc_class + .selectize-control .selectize-input {
+  text-align: left;
+}

--- a/app/www/style.css
+++ b/app/www/style.css
@@ -704,3 +704,101 @@ table.lc-landcover-tooltip-table thead tr {
   align-items: stretch;
   width: 100%;
 }
+
+/* ===== AI Assistant tab ===== */
+.ai-chat {
+  min-height: 320px;
+  max-height: 65vh;
+  overflow-y: auto;
+  padding: 10px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fafafa;
+}
+.ai-row { display: flex; }
+.ai-row.user  { justify-content: flex-end; }
+.ai-row.agent { justify-content: flex-start; }
+.ai-bubble {
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 12px;
+  margin: 6px 0;
+  max-width: 80%;
+  font-size: 0.92em;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.ai-bubble.user  { background: #1B5E20; color: #ffffff; border-bottom-right-radius: 2px; }
+.ai-bubble.agent { background: #eceff1; color: #1f2d1f; border-bottom-left-radius: 2px; }
+.ai-empty {
+  color: #8a8f8a;
+  font-style: italic;
+  text-align: center;
+  padding: 56px 16px;
+}
+
+/* Full-width row for charts/tables/maps rendered under a message (Phase 2B) */
+.ai-output-row {
+  width: 100%;
+  margin: 8px 0;
+  min-height: 200px;
+}
+
+/* Collapsible settings panel */
+.ai-settings {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  background: #ffffff;
+}
+.ai-settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+.ai-settings-title {
+  font-weight: 600;
+  color: #1f2d1f;
+  white-space: nowrap;     /* keep "Assistant settings" on one line */
+  font-size: 0.98rem;
+}
+/* Compact, subtle toggle — overrides the global full-width green button rule */
+.ai-settings-toggle.btn {
+  width: auto !important;
+  flex: 0 0 auto;
+  display: inline-flex !important;
+  align-items: center;
+  padding: 4px 14px !important;
+  font-size: 0.85rem !important;
+  line-height: 1.4;
+  color: #14532d !important;
+  background: #f1f3f4 !important;
+  border: 1px solid #cdd5cf !important;
+  border-radius: 6px !important;
+  box-shadow: none !important;
+}
+.ai-settings-toggle.btn:hover { background: #e6ebe7 !important; }
+.ai-settings-summary { color: #555; font-size: 0.92em; margin-top: 2px; }
+
+/* Input actions: prominent Ask (grows) + compact Clear on one row */
+.ai-input-actions {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+  margin-top: 8px;
+}
+.ai-send-btn.btn { flex: 1 1 auto; width: auto !important; }
+.ai-clear-btn.btn {
+  width: auto !important;
+  flex: 0 0 auto;
+  padding: 8px 16px !important;
+  color: #14532d !important;
+  background: #f1f3f4 !important;
+  border: 1px solid #cdd5cf !important;
+  box-shadow: none !important;
+}
+.ai-clear-btn.btn:hover { background: #e6ebe7 !important; }
+.ai-input-hint { color: #9aa09a; font-size: 0.8em; margin: 4px 2px 0; }


### PR DESCRIPTION
# ⚠️ Do not merge this PR before the server has been set up — see Next Steps below.

---

## Overview

This PR integrates the full data pipeline backend into the Shiny app. It introduces a three-path data loading architecture for faster and more resilient plot generation, GitHub Actions workflows for automated monthly and annual data updates, and a new AI Assistant tab for natural language Q&A over the conservation data.

---

## 1. Three-path data loading

To speed up plot generation and reduce dependency on raw raster files, the app now loads data through three paths in priority order:

| Path | Source | When used |
|---|---|---|
| 🔥 Hot path | FastAPI data service (HTTP) | API is reachable and returns data |
| ♨️ Warm path | Pre-processed Parquet files in `www/data/` | API unavailable; Parquet files present |
| ❄️ Cold path | Raw GeoTIFF rasters (original behaviour) | Fallback if both above fail |

The app gracefully degrades through each path, so it remains functional even if the API or pre-processed files are unavailable. Data update automation (Part 2) keeps the warm path outputs current.

---

## 2. Data update automation (GitHub Actions)

Three workflows have been added to automate the full pipeline — from fetching satellite imagery to deploying pre-processed outputs — with no manual steps required.

Data is processed in two passes:

- **Pass A** — monthly time-series tables (NDVI, baselines, anomalies, burned area)
- **Pass B** — annual derived analytics (resilience, phenology, delta, fire return period)

| Workflow | Trigger | UTC time | Netherlands time | Purpose |
|---|---|---|---|---|
| `monthly-update.yml` | 5th of each month | 06:13 UTC | 07:13 CET / 08:13 CEST | Fetch new month → Pass A → Pass B if new year → verify → deploy |
| `annual-update.yml` | 5 April each year | 08:13 UTC | 10:13 CEST | Forced Pass B recompute after MODIS burned area ~3-month publication lag |
| `manual-backfill.yml` | Manual dispatch only | — | — | Bounded date-range backfill for recovery or testing |

Authentication uses the `GEE_SERVICE_ACCOUNT_KEY` GitHub Secret. Failed runs automatically open a `pipeline-failure` GitHub issue for visibility.

> **Note:** All workflows are built and tested end-to-end. The final deploy step requires SSH credentials to the server — see Next Steps.

---

## 3. AI Assistant

A new **AI Assistant** tab has been added to the app, allowing users to ask natural language questions about the conservation data without needing to interpret charts manually. The assistant is powered by a tool-calling agent backed by the FastAPI data service, with support for both Anthropic and OpenAI models via LiteLLM.

### 3.1 UI

The AI Assistant tab features a redesigned full-width conversation interface with a collapsible settings panel for the AI provider and API key. Sidebar filters are hidden when the AI Assistant tab is active. The conversation area supports markdown rendering, styled HTML tables, and inline chart/map/image output below each message bubble.
<img width="1730" height="868" alt="image" src="https://github.com/user-attachments/assets/04967cc7-cafd-4215-a929-aba09b65aa49" />

### 3.2 Text and table responses

The assistant answers factual and analytical questions in natural language with markdown formatting. For questions that are better presented as structured data, it returns a rendered HTML table directly in the conversation.

*Screenshot — text response:*
<img width="1642" height="882" alt="image" src="https://github.com/user-attachments/assets/f6e7aca8-f92f-4d6f-8958-b993ff943a47" />

*Screenshot — table response:*
<img width="1311" height="490" alt="image" src="https://github.com/user-attachments/assets/8261158b-d12c-4495-8870-5eff68dcef2f" />

### 3.3 Mode A — chart and map responses using existing Shiny functions

For standard visualisation questions, the agent returns a structured chart reference and the app renders the output using its existing plotting functions. This produces fully interactive Plotly charts and Leaflet maps inline in the conversation. Supported types:

| Chart type | Description |
|---|---|
| `timeseries_monthly` | Monthly NDVI trend with historical baseline band |
| `timeseries_annual` | Year-by-year annual mean NDVI |
| `landcover` | NDVI per land cover class for a given year |
| `burned_area_monthly` | Monthly burned area vs historical baseline |
| `burned_area_daily` | Daily fire activity for a specific year |
| `anomaly` | NDVI anomaly heatmap by land cover class and month |
| `phenology` | Green-up, peak, and senescence timing |
| `delta_map` | Spatial NDVI change map between two years (Leaflet) |
| `frp_map` | Fire return period frequency map (Leaflet) |
| `burned_area_map` | Annual spatial burn extent map (Leaflet) |

*Screenshot — Plotly chart (e.g. monthly NDVI trend):*
<img width="1371" height="578" alt="image" src="https://github.com/user-attachments/assets/a03d24df-9ba5-4f7e-8c10-76a117e33c86" />

*Screenshot — Leaflet map (e.g. delta map or FRP map):*
<img width="1332" height="602" alt="image" src="https://github.com/user-attachments/assets/623623ec-8f42-4539-aa1a-2d0e024ae5d3" />

### 3.4 Mode B — agent-generated charts and tables

For custom questions involving ranking, filtering, or aggregations not covered by existing chart types, the agent computes a summary directly from the data and returns a lightweight inline chart or table. This enables flexible responses to questions like "which 3 years had the highest burned area?" without requiring a dedicated Shiny plotting function.

Supported Mode B types: `simple_bar`, `simple_line`, `simple_table`.

*Screenshot — Mode B bar chart (e.g. top years by burned area):*
<img width="1317" height="536" alt="image" src="https://github.com/user-attachments/assets/1b1fd813-17e7-4f96-be65-88b7ac797ef5" />

### 3.5 Static comparison images

For spatial comparison questions across two or more specific time periods (e.g. "compare NDVI in August 2020 vs August 2023"), the agent generates a multi-panel static PNG using the existing Shiny map generation functions, rendered inline in the conversation.

*Screenshot — comparison image (e.g. 2-panel NDVI or burn map):*
<img width="1222" height="577" alt="image" src="https://github.com/user-attachments/assets/d5002427-2612-43b6-842b-d8181c37b454" />

For full pipeline and agent documentation, see the [data pipeline README](https://github.com/Fan-shiyu/environmental-ts-data-pipeline/blob/main/README.md). 

For the full AI Assistant test suite, see the [AI Assistant — Final Comprehensive Test](https://www.notion.so/AI-Assistant-Final-Comprehensive-Test-37a1831701d181c0b8f7dbb82744c629?source=copy_link).

---

## Next steps (required before merge)

The following must be completed before this PR is merged and the pipeline runs in production:

1. **Set up the server** — upload the full historical backfill data (Sentinel-2 from 2019, MODIS from 2000) so the warm and cold paths have data to serve.

2. **Connect GitHub Actions to the server** — add SSH credentials (`SSH_HOST`, `SSH_USER`, `SSH_KEY`) to GitHub Secrets to enable the automated deploy step. Confirm `GEE_SERVICE_ACCOUNT_KEY` is set with the correct service account.

3. **Deploy the FastAPI data service** — deploy `api/` and `agent/` to the server and expose the endpoints so the Shiny app hot path can reach them.

4. *(Optional)* **Transfer repo to SensingClues organisation** — move `Fan-shiyu/environmental-ts-data-pipeline` to `SensingClues/environmental-ts-data-pipeline` and update the GitHub Actions notification email to a SensingClues address.